### PR TITLE
Default to class list by date

### DIFF
--- a/app/src/app.css
+++ b/app/src/app.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/app/src/app.html
+++ b/app/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/src/lib/components/asmblyIcon.svelte
+++ b/app/src/lib/components/asmblyIcon.svelte
@@ -1,0 +1,99 @@
+<script>
+export const svgs = {
+	Orientation: [
+		'm122.16,77.71V0H0v44.44h20.85C9.16,51.21,1.05,63.5.1,77.71h-.1v5.59h.1c1.38,20.74,18.01,37.37,38.75,38.75v.1h5.59v-.1c14.22-.95,26.5-9.06,33.27-20.75v20.85h83.3v-44.44h-38.86Zm-5.59,0h-33.27v-33.27h33.27v33.27ZM44.44,44.44h33.27v33.27h-33.27v-33.27ZM83.3,5.59h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27H5.59V5.59Zm33.27,38.96v33.16H5.69c1.36-17.66,15.5-31.81,33.16-33.16ZM5.69,83.3h33.16v33.16c-17.66-1.36-31.81-15.5-33.16-33.16Zm38.75,33.16v-33.16h33.16c-1.36,17.66-15.5,31.81-33.16,33.16Zm72.13.11h-33.27v-33.27h33.27v33.27Zm38.86,0h-33.27v-33.27h33.27v33.27Z'
+	],
+	Woodworking: [
+		'm0,0v193.44h193.44V0H0Zm51.49,23.14h118.81v96.45c-23.1-52.93-64.23-86.24-118.81-96.45Zm106.81,147.17h-26.2c-4.79-57.18-50.68-99.4-108.97-100.3v-25.67c83.61,1.92,127.71,63.52,135.17,125.96ZM23.14,119.55v-26.25c45.51,2.4,77.73,31.46,85.42,77h-26.01c-6.31-30.61-28.17-49.28-59.4-50.76Zm35.26,50.76H23.14v-27.3c21.41,1.46,31.01,14.58,35.26,27.3Z'
+	],
+	Metalworking: [
+		'm0,0v194.99h195.73V0H0Zm171.23,170.55h-106.34v-61.19h28.82v-24.44h-53.32v85.62h-15.89V24.44h146.73v146.11Z',
+		'm109.83,115.31c4.78,1.97,10.05,1.97,14.83,0,.01,0,.02-.01.04-.02l31.07-12.82c4.46-1.84,4.46-8.14,0-9.98l-31.11-12.84h0c-4.78-1.97-10.04-1.97-14.82,0-4.78,1.97-8.5,5.68-10.48,10.44-1.98,4.76-1.98,10.01,0,14.77,1.98,4.76,5.7,8.47,10.48,10.44Z'
+	],
+	'Laser Cutting': [
+		'm0,0v193.81h193.82V0H0Zm84.95,71.65l-17.8-17.8-16.91,16.92,17.79,17.8h-25.21v23.92h25.21l-17.65,17.65,16.92,16.92,17.65-17.65v24.96h23.92v-24.96l17.92,17.92,16.91-16.92-17.91-17.92h25.25v-23.92h-25.25l18.06-18.06-16.92-16.91-18.06,18.06V23.92h61.02v145.97H23.92V23.92h61.02v47.72Z'
+	],
+	'3D Printing': [
+		'm0,0v194.82h194.82V0H0Zm25.11,52.48v-27.37h48.75l-48.75,27.37Zm144.6,28.14v89.09h-60.23v-53.32l60.23-35.77Zm-50.61-55.51h50.61v30.01l-50.61-30.01Zm-22.26,15.94l44.8,26.82-44.8,26.82-48.11-26.82,48.11-26.82Zm-12.47,75.43v53.24H25.11v-86.46l59.27,33.23Z'
+	],
+	Textiles: [
+		'm0,0v193.23h193.23V0H0Zm24.11,56.66V24.11h34.09v32.56H24.11Zm0,55.8v-31.69h34.09v31.69H24.11Zm0,56.66v-32.56h34.09v32.56H24.11Zm58.2-112.46V24.11h31.7v32.56h-31.7Zm0,55.8v-31.69h31.7v31.69h-31.7Zm0,56.66v-32.56h31.7v32.56h-31.7Zm55.8-112.46V24.11h31.02v32.56h-31.02Zm0,55.8v-31.69h31.02v31.69h-31.02Zm0,56.66v-32.56h31.02v32.56h-31.02Z'
+	],
+	Electronics: [
+		'm0,0v193.32h193.32V0H0Zm169.35,51.11h-74.72c-4.74-11.54-16.08-19.7-29.31-19.7-17.47,0-31.68,14.21-31.68,31.68s14.21,31.69,31.68,31.69c13.23,0,24.58-8.16,29.31-19.7h74.72v94.27h-66.61v-10.48l12.36-12.36c4.23,2.1,8.98,3.31,14.01,3.31,17.47,0,31.68-14.21,31.68-31.68s-14.21-31.69-31.68-31.69-31.68,14.21-31.68,31.69c0,3.63.65,7.11,1.78,10.37l-20.44,20.44v20.41H23.97V23.97h145.38v27.14Zm-96.32,11.99c0,4.26-3.46,7.71-7.71,7.71s-7.71-3.46-7.71-7.71,3.46-7.71,7.71-7.71,7.71,3.46,7.71,7.71Zm48.37,55.04c0-4.26,3.46-7.71,7.71-7.71s7.71,3.46,7.71,7.71-3.46,7.71-7.71,7.71-7.71-3.46-7.71-7.71Z'
+	],
+	Miscellaneous: [
+		'm122.16,77.71V0H0v44.44h20.85C9.16,51.21,1.05,63.5.1,77.71h-.1v5.59h.1c1.38,20.74,18.01,37.37,38.75,38.75v.1h5.59v-.1c14.22-.95,26.5-9.06,33.27-20.75v20.85h83.3v-44.44h-38.86Zm-5.59,0h-33.27v-33.27h33.27v33.27ZM44.44,44.44h33.27v33.27h-33.27v-33.27ZM83.3,5.59h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27H5.59V5.59Zm33.27,38.96v33.16H5.69c1.36-17.66,15.5-31.81,33.16-33.16ZM5.69,83.3h33.16v33.16c-17.66-1.36-31.81-15.5-33.16-33.16Zm38.75,33.16v-33.16h33.16c-1.36,17.66-15.5,31.81-33.16,33.16Zm72.13.11h-33.27v-33.27h33.27v33.27Zm38.86,0h-33.27v-33.27h33.27v33.27Z'
+	]
+};
+
+function generateFillColor(category, alwaysChecked = false, checked = false) {
+	const baseColorVariants = {
+		Orientation:
+			'fill-neutral group-hover:fill-asmbly-hover stroke-neutral group-hover:stroke-asmbly-hover',
+		Woodworking: 'fill-neutral group-hover:fill-woodwork-hover',
+		Metalworking: 'fill-neutral group-hover:fill-metalwork-hover',
+		'Laser Cutting': 'fill-neutral group-hover:fill-lasers-hover',
+		'3D Printing': 'fill-neutral group-hover:fill-3dprinting-hover',
+		Textiles: 'fill-neutral group-hover:fill-textiles-hover',
+		Electronics: 'fill-neutral group-hover:fill-electronics-hover',
+		Miscellaneous:
+			'fill-neutral group-hover:fill-asmbly-hover stroke-neutral group-hover:stroke-asmbly-hover'
+	};
+
+	const checkedColorVariants = {
+		Orientation:
+			'group-hover:fill-asmbly-hover fill-asmbly-hover stroke-asmbly-hover group-hover:stroke-asmbly-hover',
+		Woodworking: 'group-hover:fill-woodwork-hover fill-woodwork-hover',
+		Metalworking: 'group-hover:fill-metalwork-hover fill-metalwork-hover',
+		'Laser Cutting': 'group-hover:fill-lasers-hover fill-lasers-hover',
+		'3D Printing': 'group-hover:fill-3dprinting-hover fill-3dprinting-hover',
+		Textiles: 'group-hover:fill-textiles-hover fill-textiles-hover',
+		Electronics: 'group-hover:fill-electronics-hover fill-electronics-hover',
+		Miscellaneous:
+			'group-hover:fill-asmbly-hover fill-asmbly-hover stroke-asmbly-hover group-hover:stroke-asmbly-hover'
+	};
+
+	const alwaysCheckedVariants = {
+		Orientation: 'stroke-accent',
+		Woodworking: 'fill-woodwork',
+		Metalworking: 'fill-metalwork',
+		'Laser Cutting': 'fill-lasers',
+		'3D Printing': 'fill-3dprinting',
+		Textiles: 'fill-textiles',
+		Electronics: 'fill-electronics',
+		Miscellaneous: 'stroke-accent'
+	};
+
+	if (checked && !alwaysChecked) {
+		return checkedColorVariants[category];
+	} else if (alwaysChecked) {
+		return alwaysCheckedVariants[category];
+	} else {
+		return baseColorVariants[category];
+	}
+}
+
+export let category = 'Orientation'
+export let alwaysChecked = false;
+export let checked = false;
+</script>
+
+<svg
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	viewBox={category === 'Miscellaneous' || category === 'Orientation'
+		? '-7.5 0 175 100'
+		: '0 0 195 195'}
+	class={"h-6 w-6 " + generateFillColor(category, alwaysChecked, checked)}
+>
+	{#each svgs[category] as svgPath}
+		<path
+			stroke-width={category === 'Miscellaneous' ||
+			category === 'Orientation'
+				? '6'
+				: '2.5'}
+			d={svgPath}
+		/>
+	{/each}
+</svg>

--- a/app/src/lib/components/calendar.svelte
+++ b/app/src/lib/components/calendar.svelte
@@ -1,0 +1,123 @@
+<script>
+	import { DateTime } from 'luxon';
+	export let selectedDate = DateTime.now()
+	export let toUrl = () => {}
+	export let highlightedDates = []
+
+	$: currentDate = selectedDate || DateTime.now()
+
+	$: daysInMonth = Array(new Date(currentDate.year, currentDate.month, 0).getDate()).keys()
+
+	$: blankDaysInMonth = Array(new Date(currentDate.year, currentDate.month - 1, 1).getDay()).keys()
+
+	function prevMonth() {
+		currentDate = currentDate.minus({ months: 1 });
+	}
+
+	function nextMonth() {
+		currentDate = currentDate.plus({ months: 1 });
+	}
+
+	function isHighlightedDate(day) {
+		const toCheck = DateTime.local(currentDate.year, currentDate.month, day + 1)
+		return highlightedDates.some(d => d.hasSame(toCheck, 'day'))
+	}
+
+	function dayToUrl(day) {
+		const dayDate = DateTime.local(currentDate.year, currentDate.month, day + 1)
+		return toUrl(dayDate)
+	}
+
+</script>
+
+<div class="flex items-center justify-between px-4">
+	<button
+		aria-label="calendar backward"
+		class="text-base-content hover:text-base-content focus:text-base-content"
+		on:click={prevMonth}
+	>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="icon icon-tabler icon-tabler-chevron-left"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			stroke-width="1.5"
+			stroke="currentColor"
+			fill="none"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path stroke="none" d="M0 0h24v24H0z" fill="none" />
+			<polyline points="15 6 9 12 15 18" />
+		</svg>
+	</button>
+	<span class="font-bold text-base-content focus:outline-none text-lg"
+		>{new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(
+			currentDate
+		)}</span
+	>
+	<button
+		aria-label="calendar forward"
+		class="text-base-content hover:text-base-content focus:text-base-content"
+		on:click={nextMonth}
+	>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="icon icon-tabler icon-tabler-chevron-right"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			stroke-width="1.5"
+			stroke="currentColor"
+			fill="none"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path stroke="none" d="M0 0h24v24H0z" fill="none" />
+			<polyline points="9 6 15 12 9 18" />
+		</svg>
+	</button>
+</div>
+<div class="flex items-center justify-between overflow-x-auto pt-12">
+	<div class="grid grid-cols-7 gap-2 p-2 lg:gap-4">
+		<div class="h-10 w-10 text-center font-light">S</div>
+		<div class="h-10 w-10 text-center font-light">M</div>
+		<div class="h-10 w-10 text-center font-light">T</div>
+		<div class="h-10 w-10 text-center font-light">W</div>
+		<div class="h-10 w-10 text-center font-light">T</div>
+		<div class="h-10 w-10 text-center font-light">F</div>
+		<div class="h-10 w-10 text-center font-light">S</div>
+		{#each daysInMonth as day}
+			{#if day === 0}
+				{#each blankDaysInMonth as _}
+					<div class="empty aspect-square h-full w-full" />
+				{/each}
+			{/if}
+			{#if isHighlightedDate(day)}
+				<div class="flex aspect-square h-full w-full flex-row items-center justify-center">
+					<div
+						class="flex aspect-square h-full w-full cursor-pointer items-center justify-center rounded-full"
+					>
+						<a
+							href={dayToUrl(day)}
+							class="{selectedDate.hasSame(
+								DateTime.local(currentDate.year, currentDate.month, day + 1),
+								'day'
+							)
+								? 'bg-primary text-primary-content'
+								: 'border-primary border-solid border-2 text-base-content '}
+								hover:bg-primary hover:text-primary-content
+								flex h-full w-full items-center justify-center rounded-full font-medium"
+							>{day + 1}</a
+						>
+					</div>
+				</div>
+			{:else}
+				<div class="aspect-square h-full w-full p-2 text-center">
+					{day + 1}
+				</div>
+			{/if}
+		{/each}
+	</div>
+</div>

--- a/app/src/lib/components/calendar.svelte
+++ b/app/src/lib/components/calendar.svelte
@@ -1,14 +1,39 @@
 <script>
 	import { DateTime } from 'luxon';
 	export let selectedDate = DateTime.now()
-	export let toUrl = () => {}
-	export let highlightedDates = []
+	export let classInstances = []
+
+	function getDaysInMonth(currentDate, classInstances) {
+		const currentMonth = currentDate.month
+		const monthDays = [...Array(currentDate.daysInMonth).keys()]
+
+		const numPrevDays = currentDate.startOf('month').weekday
+		const lastPrevDay = currentDate.minus({month: 1}).daysInMonth
+		const prevDays = [...Array(numPrevDays)].map((_v, i) => lastPrevDay - numPrevDays + i)
+
+		const numNextDays = 7 - ((currentDate.endOf('month').weekday + 1) % 7)
+		const nextDays = [...Array(numNextDays).keys()]
+
+		classInstances.forEach(c => {
+			if (c.startDateTime.month === currentMonth) {
+				monthDays[c.startDateTime.day - 1] = c
+			} else if (c.startDateTime.month === currentMonth - 1 && c.startDateTime.day >= prevDays[0]) {
+				prevDays[lastPrevDay - c.startDateTime.day] = c
+			} else if (c.startDateTime.month === currentMonth + 1 && c.startDateTime.day <= numNextDays) {
+				nextDays[c.startDateTime.day - 1] = c
+			}
+		})
+
+		return {
+			data: prevDays.concat(monthDays, nextDays),
+			startIndex: prevDays.length,
+			endIndex: prevDays.length + monthDays.length
+		}
+	}
 
 	$: currentDate = selectedDate || DateTime.now()
 
-	$: daysInMonth = Array(new Date(currentDate.year, currentDate.month, 0).getDate()).keys()
-
-	$: blankDaysInMonth = Array(new Date(currentDate.year, currentDate.month - 1, 1).getDay()).keys()
+	$: daysInMonth = getDaysInMonth(currentDate, classInstances)
 
 	function prevMonth() {
 		currentDate = currentDate.minus({ months: 1 });
@@ -18,106 +43,95 @@
 		currentDate = currentDate.plus({ months: 1 });
 	}
 
-	function isHighlightedDate(day) {
-		const toCheck = DateTime.local(currentDate.year, currentDate.month, day + 1)
-		return highlightedDates.some(d => d.hasSame(toCheck, 'day'))
-	}
-
-	function dayToUrl(day) {
-		const dayDate = DateTime.local(currentDate.year, currentDate.month, day + 1)
-		return toUrl(dayDate)
-	}
-
 </script>
-
-<div class="flex items-center justify-between px-4">
-	<button
-		aria-label="calendar backward"
-		class="text-base-content hover:text-base-content focus:text-base-content"
-		on:click={prevMonth}
-	>
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			class="icon icon-tabler icon-tabler-chevron-left"
-			width="24"
-			height="24"
-			viewBox="0 0 24 24"
-			stroke-width="1.5"
-			stroke="currentColor"
-			fill="none"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path stroke="none" d="M0 0h24v24H0z" fill="none" />
-			<polyline points="15 6 9 12 15 18" />
-		</svg>
-	</button>
-	<span class="font-bold text-base-content focus:outline-none text-lg"
-		>{new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(
-			currentDate
-		)}</span
-	>
-	<button
-		aria-label="calendar forward"
-		class="text-base-content hover:text-base-content focus:text-base-content"
-		on:click={nextMonth}
-	>
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			class="icon icon-tabler icon-tabler-chevron-right"
-			width="24"
-			height="24"
-			viewBox="0 0 24 24"
-			stroke-width="1.5"
-			stroke="currentColor"
-			fill="none"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path stroke="none" d="M0 0h24v24H0z" fill="none" />
-			<polyline points="9 6 15 12 9 18" />
-		</svg>
-	</button>
+<div>
 </div>
-<div class="flex items-center justify-between overflow-x-auto pt-12">
-	<div class="grid grid-cols-7 gap-2 p-2 lg:gap-4">
-		<div class="h-10 w-10 text-center font-light">S</div>
-		<div class="h-10 w-10 text-center font-light">M</div>
-		<div class="h-10 w-10 text-center font-light">T</div>
-		<div class="h-10 w-10 text-center font-light">W</div>
-		<div class="h-10 w-10 text-center font-light">T</div>
-		<div class="h-10 w-10 text-center font-light">F</div>
-		<div class="h-10 w-10 text-center font-light">S</div>
-		{#each daysInMonth as day}
-			{#if day === 0}
-				{#each blankDaysInMonth as _}
-					<div class="empty aspect-square h-full w-full" />
-				{/each}
-			{/if}
-			{#if isHighlightedDate(day)}
-				<div class="flex aspect-square h-full w-full flex-row items-center justify-center">
-					<div
-						class="flex aspect-square h-full w-full cursor-pointer items-center justify-center rounded-full"
-					>
-						<a
-							href={dayToUrl(day)}
-							class="{selectedDate.hasSame(
-								DateTime.local(currentDate.year, currentDate.month, day + 1),
-								'day'
-							)
-								? 'bg-primary text-primary-content'
-								: 'border-primary border-solid border-2 text-base-content '}
-								hover:bg-primary hover:text-primary-content
-								flex h-full w-full items-center justify-center rounded-full font-medium"
-							>{day + 1}</a
-						>
+<div class="rounded p-5 md:p-8 flex flex-col items-center">
+	<div class="flex items-center justify-between px-4 w-full">
+		<button
+			aria-label="calendar backward"
+			class="text-base-content hover:text-base-content focus:text-base-content"
+			on:click={prevMonth}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="icon icon-tabler icon-tabler-chevron-left"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+				fill="none"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path stroke="none" d="M0 0h24v24H0z" fill="none" />
+				<polyline points="15 6 9 12 15 18" />
+			</svg>
+		</button>
+		<span class="font-bold text-base-content focus:outline-none text-lg"
+			>{new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(
+				currentDate
+			)}</span
+		>
+		<button
+			aria-label="calendar forward"
+			class="text-base-content hover:text-base-content focus:text-base-content"
+			on:click={nextMonth}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="icon icon-tabler icon-tabler-chevron-right"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+				fill="none"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path stroke="none" d="M0 0h24v24H0z" fill="none" />
+				<polyline points="9 6 15 12 9 18" />
+			</svg>
+		</button>
+	</div>
+	<div class="flex items-center justify-between overflow-x-auto pt-12">
+		<div class="grid grid-cols-7 gap-2 p-2 lg:gap-4">
+			<div class="h-10 w-10 text-center font-light">S</div>
+			<div class="h-10 w-10 text-center font-light">M</div>
+			<div class="h-10 w-10 text-center font-light">T</div>
+			<div class="h-10 w-10 text-center font-light">W</div>
+			<div class="h-10 w-10 text-center font-light">T</div>
+			<div class="h-10 w-10 text-center font-light">F</div>
+			<div class="h-10 w-10 text-center font-light">S</div>
+			{#each daysInMonth.data as day, index}
+				{#if typeof day === "number"}
+					<div class="aspect-square h-full w-full p-2 text-center
+					{index < daysInMonth.startIndex || index >= daysInMonth.endIndex ? 'opacity-50' : ''}">
+						{day + 1}
 					</div>
-				</div>
-			{:else}
-				<div class="aspect-square h-full w-full p-2 text-center">
-					{day + 1}
-				</div>
-			{/if}
-		{/each}
+				{:else}
+					<div class="flex aspect-square h-full w-full flex-row items-center justify-center
+					{index < daysInMonth.startIndex || index >= daysInMonth.endIndex ? 'opacity-50' : ''}">
+						<div
+							class="flex aspect-square h-full w-full cursor-pointer items-center justify-center rounded-full"
+						>
+							<a
+								data-sveltekit-replacestate
+								href={day.classUrl}
+								class="{selectedDate.hasSame(day.startDateTime, 'day') ?
+									`${day.isAvailable() ? 'bg-primary text-primary-content' : 'bg-primary/40 text-base-content'} `
+									: `${day.isAvailable() ? 'border-primary' : 'border-primary/40'} border-solid border-4 text-base-content`}
+									hover:bg-primary
+									hover:border-primary hover:text-primary-content
+									flex h-full w-full items-center justify-center rounded-full font-medium"
+								>{day.startDateTime.day}</a
+							>
+						</div>
+					</div>
+				{/if}
+			{/each}
+		</div>
 	</div>
 </div>

--- a/app/src/lib/components/classCard.svelte
+++ b/app/src/lib/components/classCard.svelte
@@ -1,0 +1,50 @@
+<script context="module">
+	import AsmblyIcon from '$lib/components/asmblyIcon.svelte'
+	import { DateTime } from 'luxon';
+	const classImages = import.meta.glob('$lib/images/*.{avif,gif,heif,jpeg,jpg,png,tiff,webp}', {
+		eager: true,
+		query: {
+			enhanced: true
+		}
+	});
+</script>
+
+<script>
+	export let filters = {};
+	export let event;
+
+	$: summaryLength = filters.compact ? 100 : 200;
+
+	$: summary = event.summary ? `${event.summary.substring(0, summaryLength)}${event.summary.length > summaryLength ? '...' : ''}` : 'No summary available'
+</script>
+
+{#if event}
+<div class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:max-h-80">
+	<figure class="{filters.compact ? ' lg:w-1/3' : 'w-full lg:w-4/5'}">
+		<enhanced:img
+			class="object-cover h-full {filters.compact ? 'hidden lg:block' : ''}"
+			src={event.getClassImage(classImages)}
+			alt="{event.name} image"
+		/>
+	</figure>
+	<div class="card-body w-full {filters.compact ? 'p-4' : ''}">
+		<div class="flex justify-between items-baseline flex-wrap">
+			<h2 class="font-asmbly text-accent card-title font-light">{event.name}</h2>
+			<div class="grid h-8 w-8 place-items-center {filters.compact ? 'order-last' : ''}">
+				<AsmblyIcon category={event.category} alwaysChecked={true} />
+			</div>
+		</div>
+		<p class="text-lg">{#if filters.groupByClass} Next Class: {/if} <b>
+			{event.startDateTime.toLocaleString('en-US', {dateStyle: "short", timeStyle: "short"})}</b>&nbsp;at
+						{event.startDateTime.toLocaleString(DateTime.TIME_SIMPLE)}
+		</p>
+		<div class="">
+				<p class="text-md">{summary}</p>
+				<p class="inline-block">Price: {event.price === 0 ? 'Free' : '$' + event.price + '.00'}</p>
+			<div class="card-actions content-center float-right">
+				<a class="btn btn-primary rounded-none" href="/event/{event.typeId}?eventId={event.eventId}" aria-label="learn more about {event.name} class">Learn More</a>
+			</div>
+		</div>
+	</div>
+</div>
+{/if}

--- a/app/src/lib/components/classList.svelte
+++ b/app/src/lib/components/classList.svelte
@@ -1,0 +1,135 @@
+<script>
+	import NeonEventType from '$lib/models/neonEventType.js'
+	import NeonEventInstance from '$lib/models/neonEventInstance.js'
+	import AsmblyIcon from '$lib/components/asmblyIcon.svelte'
+	import Fuse from 'fuse.js';
+	import { DateTime } from 'luxon';
+
+	export let classJson = []
+	export let filters = {}
+	export let categoryMap = new Map()
+
+	const classImages = import.meta.glob('$lib/images/*.{avif,gif,heif,jpeg,jpg,png,tiff,webp}', {
+		eager: true,
+		query: {
+			enhanced: true
+		}
+	});
+
+	const classTypeList = classJson.map(c => new NeonEventType(c));
+
+	function filterClasses(classList, categoryMap, filters) {
+
+		// check for category filters
+		const categories = []
+		for (const [k,v] of categoryMap) {
+			if (v) categories.push({category: `=${k}`})
+		}
+
+		// initialize query and keys
+		let query = {$and: []};
+		let keys = []
+
+		// generate query based on what's available
+		if (filters.searchTerm) {
+			query.$and.push({name: filters.searchTerm})
+			keys.push('name')
+		}
+		if (categories.length) {
+			query.$and.push({$or: categories})
+			keys.push('category')
+		}
+
+		let result
+		// query or return all
+		if (keys.length) {
+			const fuse = new Fuse(classList, {
+				useExtendedSearch: true,
+				includeScore: true,
+				threshold: 0.25,
+				keys,
+			})
+			result = fuse.search(query).map(i => i.item)
+		} else {
+			result = classList
+		}
+
+		// hide full or past
+		if (!filters.showAll) {
+			const now = DateTime.local({zone: 'America/Chicago'})
+			result = result.filter(r => r.isAvailable(filters.groupByClass))
+		}
+
+		// sort
+		return result.sort((a,b) => a.compare(b, filters.sortBy, filters.sortAsc))
+	}
+
+	$: allClassList = classTypeList.map(t => t.instanceList(filters.groupByClass)).flat()
+
+	$: filteredClassList = filterClasses(allClassList, categoryMap, filters);
+</script>
+
+{#each filteredClassList as event}
+	<div class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:max-h-80">
+		<figure class="w-full lg:w-4/5">
+			<enhanced:img
+				class="object-cover h-full"
+				src={event.getClassImage(classImages)}
+				alt="{event.name} image"
+			/>
+		</figure>
+
+		<div class="card-body w-full">
+			<div class="flex justify-between">
+				<h2 class="font-asmbly text-accent card-title font-light">{event.name}</h2>
+				<div class="grid h-8 w-8 place-items-center">
+					<AsmblyIcon category={event.category} alwaysChecked={true} />
+				</div>
+			</div>
+			<p class="text-lg">{#if filters.groupByClass} Next Class: {/if} <b>
+				{event.startDateTime.toLocaleString('en-US', {dateStyle: "short", timeStyle: "short"})}
+			</b></p>
+			{#if event.summary}
+			<p class="text-md">
+				{event.summary.length > 200
+					? event.summary.substring(0, 200) + '...'
+					: event.summary}
+			</p>
+			{:else}
+			<p class="text-md">No summary available</p>
+			{/if}
+			<div class="card-actions content-center justify-end">
+				<p>Price: {event.price === 0 ? 'Free' : '$' + event.price + '.00'}</p>
+				<a class="btn btn-primary rounded-none" href="/event/{event.typeId}?eventId={event.eventId}">Learn More</a>
+			</div>
+		</div>
+	</div>
+{/each}
+{#if filteredClassList.length === 0}
+	<div
+		class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:mr-64 lg:max-h-64"
+	>
+		<figure class="h-64 w-full lg:w-4/5">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 -960 960 960"
+				class="h-full w-full fill-base-content"
+				><path
+					d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"
+				/></svg
+			>
+		</figure>
+		<div class="card-body w-full">
+			<h2 class="font-asmbly text-accent card-title font-light">Sorry, no results found</h2>
+			<p class="text-md">
+				We couldn't find any classes that match your search. Try adjusting your filters or
+				checking your spelling.
+			</p>
+			<div class="card-actions content-center justify-end">
+				<button on:click={() => filters.searchTerm = ''} class="btn btn-primary rounded-none"
+					>Clear Search</button
+				>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/app/src/lib/components/classList.svelte
+++ b/app/src/lib/components/classList.svelte
@@ -1,20 +1,13 @@
 <script>
 	import NeonEventType from '$lib/models/neonEventType.js'
 	import NeonEventInstance from '$lib/models/neonEventInstance.js'
-	import AsmblyIcon from '$lib/components/asmblyIcon.svelte'
+	import ClassCard from '$lib/components/classCard.svelte'
 	import Fuse from 'fuse.js';
 	import { DateTime } from 'luxon';
 
 	export let classJson = []
 	export let filters = {}
 	export let categoryMap = new Map()
-
-	const classImages = import.meta.glob('$lib/images/*.{avif,gif,heif,jpeg,jpg,png,tiff,webp}', {
-		eager: true,
-		query: {
-			enhanced: true
-		}
-	});
 
 	const classTypeList = classJson.map(c => new NeonEventType(c));
 
@@ -23,7 +16,7 @@
 		// check for category filters
 		const categories = []
 		for (const [k,v] of categoryMap) {
-			if (v) categories.push({category: `=${k}`})
+			if (v) categories.push({category: `="${k}"`})
 		}
 
 		// initialize query and keys
@@ -69,67 +62,36 @@
 	$: filteredClassList = filterClasses(allClassList, categoryMap, filters);
 </script>
 
-{#each filteredClassList as event}
-	<div class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:max-h-80">
-		<figure class="w-full lg:w-4/5">
-			<enhanced:img
-				class="object-cover h-full"
-				src={event.getClassImage(classImages)}
-				alt="{event.name} image"
-			/>
-		</figure>
-
-		<div class="card-body w-full">
-			<div class="flex justify-between">
-				<h2 class="font-asmbly text-accent card-title font-light">{event.name}</h2>
-				<div class="grid h-8 w-8 place-items-center">
-					<AsmblyIcon category={event.category} alwaysChecked={true} />
+<div class="scroll-smooth">
+	{#each filteredClassList as event}
+		<ClassCard filters={filters} event={event}/>
+	{/each}
+	{#if filteredClassList.length === 0}
+		<div
+			class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:mr-64 lg:max-h-64"
+		>
+			<figure class="h-64 w-full lg:w-4/5">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 -960 960 960"
+					class="h-full w-full fill-base-content"
+					><path
+						d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"
+					/></svg
+				>
+			</figure>
+			<div class="card-body w-full">
+				<h2 class="font-asmbly text-accent card-title font-light">Sorry, no results found</h2>
+				<p class="text-md">
+					We couldn't find any classes that match your search. Try adjusting your filters or
+					checking your spelling.
+				</p>
+				<div class="card-actions content-center justify-end">
+					<button on:click={() => filters.searchTerm = ''} class="btn btn-primary rounded-none"
+						>Clear Search</button
+					>
 				</div>
 			</div>
-			<p class="text-lg">{#if filters.groupByClass} Next Class: {/if} <b>
-				{event.startDateTime.toLocaleString('en-US', {dateStyle: "short", timeStyle: "short"})}
-			</b></p>
-			{#if event.summary}
-			<p class="text-md">
-				{event.summary.length > 200
-					? event.summary.substring(0, 200) + '...'
-					: event.summary}
-			</p>
-			{:else}
-			<p class="text-md">No summary available</p>
-			{/if}
-			<div class="card-actions content-center justify-end">
-				<p>Price: {event.price === 0 ? 'Free' : '$' + event.price + '.00'}</p>
-				<a class="btn btn-primary rounded-none" href="/event/{event.typeId}?eventId={event.eventId}">Learn More</a>
-			</div>
 		</div>
-	</div>
-{/each}
-{#if filteredClassList.length === 0}
-	<div
-		class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:mr-64 lg:max-h-64"
-	>
-		<figure class="h-64 w-full lg:w-4/5">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox="0 -960 960 960"
-				class="h-full w-full fill-base-content"
-				><path
-					d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"
-				/></svg
-			>
-		</figure>
-		<div class="card-body w-full">
-			<h2 class="font-asmbly text-accent card-title font-light">Sorry, no results found</h2>
-			<p class="text-md">
-				We couldn't find any classes that match your search. Try adjusting your filters or
-				checking your spelling.
-			</p>
-			<div class="card-actions content-center justify-end">
-				<button on:click={() => filters.searchTerm = ''} class="btn btn-primary rounded-none"
-					>Clear Search</button
-				>
-			</div>
-		</div>
-	</div>
-{/if}
+	{/if}
+</div>

--- a/app/src/lib/models/neonEventInstance.js
+++ b/app/src/lib/models/neonEventInstance.js
@@ -1,0 +1,73 @@
+export default class neonEventInstance {
+	constructor (instance, eventType) {
+		this.eventId = instance.eventId
+		this.attendees = instance.attendeeCount || instance.attendees
+		this.teacher = instance.teacher.name || instance.teacher
+		this.startDateTime = instance.startDateTime
+		this.endDateTime = instance.endDateTime
+		this.price = instance.price
+		this.summary = instance.summary
+		this.capacity = instance.capacity
+		this.category =  eventType.category
+		this.name = eventType.name
+		this.typeId = eventType.typeId
+		this.isPast = instance.startDateTime < Date.now()
+		this.isFull = this.attendees >= this.capacity
+	}
+
+	toJson() {
+		return {...this}
+	}
+
+	isAvailable(skipCapacityCheck) {
+		return !this.isPast && (
+			skipCapacityCheck || !this.isFull
+		)
+	}
+
+	compare(o, type, sortAscending) {
+		let sort = 0;
+		switch(type){
+		case 'Date':
+			sort = this.isPast * 1 + o.isPast * -1
+			if (!sort) {
+				sort = this.startDateTime - o.startDateTime
+				if (Math.abs(sort) < 1000) sort = 0;
+			}
+			break;
+		case 'Price':
+			sort = this.price - o.price;
+			break
+		}
+
+		if (!sort) {
+			sort = this.name.toLowerCase().localeCompare(o.name.toLowerCase())
+		}
+
+		if (!sortAscending) {
+			sort *= -1
+		}
+
+		return sort
+	}
+
+	getClassImage(classImages) {
+		let result = classImages['/src/lib/images/' + this.name.replace(/\s+/g, '_') + '.jpg'];
+
+		if (typeof result === 'undefined' || result === null) {
+			switch (this.category) {
+				case 'Laser Cutting':
+					result = classImages['/src/lib/images/lasersDefault.jpg'];
+					break;
+				default:
+					const imgPath = this.category.replace(' ', '').toLowerCase()
+					result = classImages[`/src/lib/images/${imgPath}Default.jpg`]
+			}
+		}
+		if (typeof result === 'undefined' || result === null) {
+			result = classImages['/src/lib/images/classDefault.jpg'];
+		}
+
+		return result.default;
+	}
+}

--- a/app/src/lib/models/neonEventInstance.js
+++ b/app/src/lib/models/neonEventInstance.js
@@ -29,10 +29,8 @@ export default class NeonEventInstance {
 		}
 	}
 
-	isAvailable(skipCapacityCheck) {
-		return !this.isPast && (
-			skipCapacityCheck || !this.isFull
-		)
+	isAvailable() {
+		return !this.isPast && !this.isFull
 	}
 
 	compare(o, type, sortAscending) {

--- a/app/src/lib/models/neonEventInstance.js
+++ b/app/src/lib/models/neonEventInstance.js
@@ -1,22 +1,32 @@
-export default class neonEventInstance {
+import { DateTime } from 'luxon';
+
+export default class NeonEventInstance {
 	constructor (instance, eventType) {
 		this.eventId = instance.eventId
-		this.attendees = instance.attendeeCount || instance.attendees
+		this.attendees = instance.attendeeCount || instance.attendees || 0
 		this.teacher = instance.teacher.name || instance.teacher
-		this.startDateTime = instance.startDateTime
-		this.endDateTime = instance.endDateTime
+		this.startDateTime = DateTime.fromJSDate(instance.startDateTime)
+		this.endDateTime = DateTime.fromJSDate(instance.endDateTime)
 		this.price = instance.price
 		this.summary = instance.summary
 		this.capacity = instance.capacity
 		this.category =  eventType.category
 		this.name = eventType.name
 		this.typeId = eventType.typeId
-		this.isPast = instance.startDateTime < Date.now()
+		this.isPast = instance.startDateTime < DateTime.now()
 		this.isFull = this.attendees >= this.capacity
 	}
 
+	get classUrl() {
+		return `?eventId=${this.eventId}`
+	}
+
 	toJson() {
-		return {...this}
+		return {
+			...this,
+			startDateTime: this.startDateTime.toJSDate(),
+			endDateTime: this.endDateTime.toJSDate()
+		}
 	}
 
 	isAvailable(skipCapacityCheck) {

--- a/app/src/lib/models/neonEventType.js
+++ b/app/src/lib/models/neonEventType.js
@@ -1,0 +1,66 @@
+import NeonEventInstance from './neonEventInstance.js';
+
+export default class NeonEventType {
+	constructor(event) {
+		this.category = event.category;
+		this.name = event.name;
+		this.typeId = event.typeId;
+		this.classInstances = [];
+		this.isPrivate = event.isPrivate;
+		this.sorted = false;
+
+		if (this.name.match(/Private|Checkout/)) {
+			this.isPrivate = true
+		}
+
+		if (event.classInstances) this.addInstances(...event.classInstances)
+	}
+
+	addInstances(...instances) {
+		for (const instance of instances) {
+			this.classInstances.push(new NeonEventInstance(instance, this))
+		}
+		this.sorted = false
+	}
+
+	sortInstances() {
+		if (this.sorted) return
+
+		this.classInstances.sort((a, b) => a.startDateTime - b.startDateTime)
+		this.sorted = true
+	}
+
+	soonestDateTime() {
+		this.sortInstances();
+		const latest = this.classInstances[0]?.startDateTime
+		if (latest && latest > Date.now()) {
+			return latest
+		}
+
+		return Infinity
+	}
+
+	instanceList(soonestOnly) {
+		this.sortInstances()
+		return soonestOnly ? this.classInstances[0] : this.classInstances
+	}
+
+	toJson() {
+		return {
+			...this,
+			classInstances: this.classInstances.map(i => i.toJson())
+		}
+	}
+}
+
+NeonEventType.fromPrisma = function(prismaNeonEventType) {
+	let isPrivate, category;
+	prismaNeonEventType.category.forEach(cat => {
+		if (cat.archCategories.name === 'Private') {
+			isPrivate = true
+		} else {
+			category = cat.archCategories.name
+		}
+	})
+	return new NeonEventType({...prismaNeonEventType, typeId: prismaNeonEventType.id, isPrivate, category})
+}

--- a/app/src/lib/models/neonEventType.js
+++ b/app/src/lib/models/neonEventType.js
@@ -1,4 +1,4 @@
-import NeonEventInstance from './neonEventInstance.js';
+import NeonEventInstance from '$lib/models/neonEventInstance.js';
 
 export default class NeonEventType {
 	constructor(event) {
@@ -8,6 +8,7 @@ export default class NeonEventType {
 		this.classInstances = [];
 		this.isPrivate = event.isPrivate;
 		this.sorted = false;
+		this.anyCurrent = false;
 
 		if (this.name.match(/Private|Checkout/)) {
 			this.isPrivate = true
@@ -16,9 +17,15 @@ export default class NeonEventType {
 		if (event.classInstances) this.addInstances(...event.classInstances)
 	}
 
+	get summary() {
+		return classInstances[0].summary
+	}
+
 	addInstances(...instances) {
 		for (const instance of instances) {
-			this.classInstances.push(new NeonEventInstance(instance, this))
+			const instanceModel = new NeonEventInstance(instance, this)
+			this.classInstances.push(instanceModel);
+			if (!instanceModel.isPast) this.anyCurrent = true;
 		}
 		this.sorted = false
 	}
@@ -56,6 +63,7 @@ export default class NeonEventType {
 NeonEventType.fromPrisma = function(prismaNeonEventType) {
 	let isPrivate, category;
 	prismaNeonEventType.category.forEach(cat => {
+		if (!cat.archCategories) return
 		if (cat.archCategories.name === 'Private') {
 			isPrivate = true
 		} else {

--- a/app/src/lib/models/neonEventType.js
+++ b/app/src/lib/models/neonEventType.js
@@ -37,19 +37,22 @@ export default class NeonEventType {
 		this.sorted = true
 	}
 
-	soonestDateTime() {
+	soonest(showAll) {
 		this.sortInstances();
-		const latest = this.classInstances[0]?.startDateTime
-		if (latest && latest > Date.now()) {
-			return latest
+		if (showAll) return this.classInstances[0]
+
+		for (let i = 0; i < this.classInstances.length; i++) {
+			if (this.classInstances[i].isAvailable()) {
+				return this.classInstances[i]
+			}
 		}
 
-		return Infinity
+		return this.classInstances[0]
 	}
 
-	instanceList(soonestOnly) {
+	instanceList(soonestOnly, showAll) {
 		this.sortInstances()
-		return soonestOnly ? this.classInstances[0] : this.classInstances
+		return soonestOnly ? this.soonest(showAll) : this.classInstances
 	}
 
 	toJson() {

--- a/app/src/routes/(data-pages)/+layout.server.js
+++ b/app/src/routes/(data-pages)/+layout.server.js
@@ -1,5 +1,6 @@
 import { prisma } from '$lib/postgres.js';
 import { DateTime } from 'luxon';
+import NeonEventType from '$lib/models/neonEventType.js'
 
 export const prerender = false;
 
@@ -28,7 +29,6 @@ export async function load() {
 				orderBy: {
 					startDateTime: 'asc'
 				},
-				take: 1,
 				include: {
 					teacher: {
 						select: {
@@ -48,26 +48,14 @@ export async function load() {
 	const classCategories = new Set();
 
 	for (const event of eventTypes) {
-		const instanceCategory = event.category.find((cat) => cat.archCategories.name !== 'Private');
-		if (!instanceCategory) {
+		const eventModel = NeonEventType.fromPrisma(event)
+		if (eventModel.isPrivate) {
 			continue;
 		}
-		classCategories.add(instanceCategory.archCategories.name);
-		let classContext = {};
-		const instances = event.instances;
-		let classInstances = [];
-		if (instances.length > 0) {
-			for (const instance of instances) {
-				let instanceContext = {};
-				instanceContext.eventId = instance.eventId;
-				instanceContext.attendees = instance.attendeeCount;
-				instanceContext.teacher = instance.teacher.name;
-				instanceContext.startDateTime = instance.startDateTime;
-				instanceContext.endDateTime = instance.endDateTime;
-				instanceContext.price = instance.price;
-				instanceContext.summary = instance.summary;
-				classInstances.push(instanceContext);
-			}
+
+		classCategories.add(eventModel.category);
+		if (event.instances.length > 0) {
+			eventModel.addInstances(...event.instances)
 		} else {
 			const noCurrentInstances = await prisma.neonEventInstance.findMany({
 				where: {
@@ -92,31 +80,18 @@ export async function load() {
 			});
 
 			if (noCurrentInstances.length > 0) {
-				for (const instance of noCurrentInstances) {
-					let instanceContext = {};
-					instanceContext.eventId = instance.eventId;
-					instanceContext.attendees = instance.attendeeCount;
-					instanceContext.teacher = instance.teacher.name;
-					instanceContext.startDateTime = instance.startDateTime;
-					instanceContext.endDateTime = instance.endDateTime;
-					instanceContext.price = instance.price;
-					instanceContext.summary = instance.summary;
-					classInstances.push(instanceContext);
-				}
+				eventModel.addInstances(...noCurrentInstances)
 			}
 		}
-		
-		classContext.classInstances = classInstances;
-		classContext.name = event.name;
-		classContext.category = instanceCategory.archCategories.name;
-		classContext.typeId = event.id;
 
-		const name_split = classContext.name.split(' ');
-
-		if (!name_split.includes('Private') && !name_split.includes('(Private)') && !name_split.includes('Checkout') && !name_split.includes('(Checkout)') && classContext.category !== 'Private' ) {
-			classJson.push(classContext);
-		}
+		classJson.push(eventModel.toJson());
 	}
 
-	return { classJson, classCategories, baseRegLink };
+	const classCategoriesSorted = [...classCategories].sort((a,b) => {
+		if (a === 'Orientation') return -1
+		if (b === 'Orientation') return 1
+		return a.localeCompare(b)
+	})
+
+	return { classJson, classCategories: classCategoriesSorted, baseRegLink };
 }

--- a/app/src/routes/(data-pages)/+page.svelte
+++ b/app/src/routes/(data-pages)/+page.svelte
@@ -63,8 +63,10 @@
 		groupByClass: false,
 		showAll: false,
 		searchTerm: '',
+		compact: false
 	}
 
+	let sortDropdownOpen = false
 </script>
 
 <svelte:head>
@@ -72,119 +74,105 @@
 	<meta name="description" content="View and sign up for classes at Asmbly." />
 	<meta name="keywords" content="classes, asmbly, woodworking, metalworking, woodshop, CNC, laser, sewing, textiles, electronics, 3d, printing" />
 </svelte:head>
-
-<div class="drawer flex justify-center lg:drawer-open lg:min-h-[calc(100dvh-10rem)] 2xl:min-h-[calc(100dvh-20rem)]">
+<div class="drawer max-lg:drawer-end justify-center items-stretch lg:drawer-open lg:min-h-[calc(100dvh-10rem)] 2xl:min-h-[calc(100dvh-20rem)]">
 	<input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-	<div class="drawer-content order-2">
-		<!-- Page content here -->
-		<div class="mt-4 flex justify-start">
-			<div class="grid place-content-start lg:max-w-4xl" use:autoAnimate>
-				<div class="grid grid-rows-2 lg:flex lg:items-center lg:justify-start">
-					<div
-						class="relative row-start-1 flex w-full flex-1 px-2 text-neutral focus-within:text-neutral lg:max-w-sm"
-					>
-						<span class="absolute inset-y-0 left-0 flex items-center pl-2">
-							<button type="submit" class="focus:shadow-outline p-1 focus:outline-none">
-								<svg
-									fill="none"
-									stroke="currentColor"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									viewBox="0 0 24 24"
-									class="h-6 w-6"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-							</button>
-						</span>
-						<input
-							type="search"
-							name="q"
-							class="my-2 w-full bg-base-300 py-2 pl-10 text-sm text-neutral placeholder:italic placeholder:text-neutral focus:bg-secondary focus:text-secondary-content focus:outline-none"
-							placeholder="Search by class name..."
-							autocomplete="off"
-							bind:value={filters.searchTerm}
-						/>
-					</div>
-					<div class="row-start-2 flex justify-center">
-						<div>
-							<button on:click={() => filters.groupByClass = !filters.groupByClass} class="btn btn-ghost rounded-none lg:ml-2"
-								>Group By: {filters.groupByClass ? 'Class Type' : 'Date'}
-								<svg
-									fill="none"
-									viewBox="0 0 20 20"
-									class="h-4 w-4 transform transition-transform duration-200"
-									><path
-										class="fill-base-content"
-										fill-rule="evenodd"
-										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-										clip-rule="evenodd"
-									/></svg
-								>
-							</button>
-						</div>
-						<details id="sortDropdown" class="dropdown">
-							<summary class="btn btn-ghost rounded-none lg:ml-2"
-								>Sort by: {filters.sortBy}
-								<svg
-									fill="none"
-									viewBox="0 0 20 20"
-									class="h-4 w-4 transform transition-transform duration-200"
-									><path
-										class="fill-base-content"
-										fill-rule="evenodd"
-										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-										clip-rule="evenodd"
-									/></svg
-								>
-							</summary>
+	<div class="drawer-side z-10 lg:p-2 row-start-2">
+		<label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay" />
+		<div class="bg-base-200 w-80 min-h-full p-4">
+			<label class="input input-sm input-primary w-full block flex justify-center">
+			<input
+			type="search"
+			name="q"
+			class="grow bg-transparent"
+			placeholder="Search by class name..."
+			autocomplete="off"
+			bind:value={filters.searchTerm}
+			/>
+			<button type="submit" class="p-1 material-symbols-outlined">
+				search
+			</button>
+		</label>
+		<div class="divider mt-0 lg:hidden" />
+			<h2 class="px-2 font-asmbly font-light divider text-lg">Sort</h2>
+			<div class="px-4">
+				<label class="label" >
+					Sort By
+						<select class="select select-sm z-10 bg-base-200 px-4 font-bold text-base hover:bg-base-300 focus:bg-base-300 border-none" bind:value={filters.sortBy}>
+							<option value="Date"> Date</option>
+							<option value="Name"> Name</option>
+							<option value="Price"> Price</option>
+						</select>
+				</label>
+				<label class="label cursor-pointer group">
+					Sort Order
+				  <div class="swap">
+				  	<input type="checkbox" class="peer" bind:checked={filters.sortAsc}/>
+				  	<div class="swap-on group-hover:bg-base-300 peer-focus:bg-base-300 btn btn-sm shadow-none px-2 text-base">Low to High</div>
+			  	  <div class="swap-off group-hover:bg-base-300 peer-focus:bg-base-300 btn btn-sm shadow-none px-2 text-base">High to Low</div>
+		  	 	</div>
+				</label>
+			</div>
+			<h2 class="px-2 font-asmbly font-light divider text-lg">View</h2>
+			<div class="px-4">
+				<label class="label cursor-pointer">
+					Group By Class Type
+				  <input type="checkbox" bind:checked={filters.groupByClass} class="checkbox rounded-none"/>
+				</label>
 
-							<ul
-								class="menu dropdown-content z-[1] w-40 rounded-none bg-base-100 p-2 shadow-xl"
-							>
-								<li><button class="rounded-none" on:click={() => sortClickHandler('Date')}>Date</button></li>
-								<li><button class="rounded-none" on:click={() => sortClickHandler('Name')}>Name</button></li>
-								<li>
-									<button class="rounded-none" on:click={() => sortClickHandler('Price')}>Price</button>
-								</li>
-							</ul>
-						</details>
-						<div>
-							<button on:click={() => sortOrderHandler()} class="btn btn-ghost rounded-none lg:ml-2"
-								>Order: {filters.sortAsc ? 'Asc' : 'Desc'}
-								<svg
-									fill="none"
-									viewBox="0 0 20 20"
-									class="h-4 w-4 transform transition-transform duration-200 {filters.sortAsc ? 'rotate-180' : ''}"
-									><path
-										class="fill-base-content"
-										fill-rule="evenodd"
-										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-										clip-rule="evenodd"
-									/></svg
-								>
-							</button>
+				<label class="label cursor-pointer">
+					Show Unavailable Classes
+					<input type="checkbox" bind:checked={filters.showAll} class="checkbox rounded-none"/>
+				</label>
+				<label class="label cursor-pointer group">
+					Spacing
+				  <div class="swap ">
+				  	<input type="checkbox" bind:checked={filters.compact} class="peer"/>
+				  	<div class="swap-on text-right group-hover:bg-base-300 peer-focus:bg-base-300 btn btn-sm shadow-none px-2 text-base">Compact</div>
+			  	  <div class="swap-off text-right group-hover:bg-base-300 peer-focus:bg-base-300 btn btn-sm shadow-none px-2 text-base">Comfy</div>
+		  	 	</div>
+				</label>
+			</div>
+			<h2 class="px-2 font-asmbly font-light divider text-lg">Filter by Category</h2>
+			<ul
+				class="min-h-full md:min-h-max overflow-y-auto px-4 text-base-content lg:bg-transparent"
+			>
+				<!-- Sidebar content here -->
+				{#each [...archCategories.keys()] as category}
+					<li>
+						<div class="form-control">
+							<label class="group label cursor-pointer">
+								<div class="flex items-center gap-4">
+									<div
+										class="grid place-items-center {generateBackgroundColor(
+											category
+										)} h-8 w-8 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.10)] group-hover:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.2)]"
+									>
+									<AsmblyIcon category={category} checked={archCategories.get(category)} />
+									</div>
+									<span class="group-hover:text-base-content/60">{category}</span>
+								</div>
+								<input
+									on:change={() => toggleArchCategory(category)}
+									type="checkbox"
+									checked=""
+									class="checkbox rounded-none"
+									name={category}
+								/>
+							</label>
 						</div>
-						<div>
-							<button on:click={() => filters.showAll = !filters.showAll} class="btn btn-ghost rounded-none lg:ml-2">{filters.showAll ? 'Hide Unavailable' : 'Show Unavailable'}
-								<svg
-									fill="none"
-									viewBox="0 0 20 20"
-									class="h-4 w-4 transform transition-transform duration-200"
-									><path
-										class="fill-base-content"
-										fill-rule="evenodd"
-										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-										clip-rule="evenodd"
-									/></svg
-								>
-							</button>
-						</div>
-					</div>
-				</div>
-				<div class="divider mx-2 mt-0 lg:hidden" />
-				<div class="mx-2 mb-4 flex justify-center">
+					</li>
+				{/each}
+			</ul>
+		</div>
+	</div>
+	<div class="drawer-content row-start-2">
+		<!-- Page content here -->
+		<div class="flex justify-start mt-2">
+			<div class="grid place-content-start lg:max-w-4xl" use:autoAnimate>
+				<div class="mx-2 mb-4 flex justify-center lg:hidden">
 					<label
 						for="my-drawer-2"
-						class="btn btn-primary drawer-button btn-block flex rounded-none lg:hidden"
+						class="btn btn-primary drawer-button btn-block flex rounded-none "
 					>
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
@@ -204,40 +192,5 @@
 				<ClassList classJson={data.classJson} filters={filters} categoryMap={archCategories}/>
 			</div>
 		</div>
-	</div>
-	<div class="drawer-side order-1 h-full md:max-h-max lg:ml-2 lg:mt-2 lg:pl-2 lg:pt-2">
-		<label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay" />
-		<ul
-			class="min-h-full md:min-h-max w-64 overflow-y-auto bg-base-200 p-4 text-base-content lg:bg-transparent xl:w-80"
-		>
-			<!-- Sidebar content here -->
-			<h2 class="pl-2 font-asmbly font-light">Filter by Category</h2>
-			<li class="divider" />
-			{#each [...archCategories.keys()] as category}
-				<li>
-					<div class="form-control mr-2">
-						<label class="group label cursor-pointer">
-							<div class="flex items-center gap-4">
-								<div
-									class="grid place-items-center {generateBackgroundColor(
-										category
-									)} h-8 w-8 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.10)] group-hover:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.2)]"
-								>
-								<AsmblyIcon category={category} checked={archCategories.get(category)} />
-								</div>
-								<span class="label-text group-hover:text-base-content/60">{category}</span>
-							</div>
-							<input
-								on:change={() => toggleArchCategory(category)}
-								type="checkbox"
-								checked=""
-								class="checkbox rounded-none"
-								name={category}
-							/>
-						</label>
-					</div>
-				</li>
-			{/each}
-		</ul>
 	</div>
 </div>

--- a/app/src/routes/(data-pages)/+page.svelte
+++ b/app/src/routes/(data-pages)/+page.svelte
@@ -22,8 +22,9 @@
 	let archCategories = new Map(archCategoriesBase);
 	afterNavigate(async (nav) => {
 		filters = {...defaultFilters}
+		const searchParams = nav.to.url.searchParams
 		for(const key in filters) {
-			const val = nav.to.url.searchParams.get(key)
+			const val = searchParams.get(key)
 			if (val === null) continue;
 			if (key === 'sortBy') {
 				if (val.match(/^(Date|Price|Name)$/)) filters[key] = val
@@ -33,13 +34,15 @@
 		}
 
 		let newCategories = new Map(archCategoriesBase)
-		for (const cat of nav.to.url.searchParams.getAll('archCategories')) {
+		for (const cat of searchParams.getAll('archCategories')) {
 			if (newCategories.get(cat) !== undefined) {
 				newCategories.set(cat, true)
 			}
 		}
 
 		archCategories = newCategories
+
+		filters.searchTerm = searchParams.get('searchTerm') || ''
 	})
 
 	const hoverColorVariants = {
@@ -97,7 +100,9 @@
 			query.set(key, value);
     }
 
-		goto(`?${query.toString()}`);
+		goto(`?${query.toString()}`, {
+			keepFocus: true,
+		});
 	}
 
 
@@ -122,6 +127,7 @@
 			placeholder="Search by class name..."
 			autocomplete="off"
 			bind:value={filters.searchTerm}
+			on:input={(evt) => updateSearchParams('searchTerm', evt.target.value)}
 			/>
 			<button type="submit" class="p-1 material-symbols-outlined">
 				search

--- a/app/src/routes/(data-pages)/+page.svelte
+++ b/app/src/routes/(data-pages)/+page.svelte
@@ -1,196 +1,46 @@
 <script>
-	import Fuse from 'fuse.js';
 	import autoAnimate from '@formkit/auto-animate';
-	import { DateTime } from 'luxon';
+	import AsmblyIcon from '$lib/components/asmblyIcon.svelte'
+	import ClassList from '$lib/components/classList.svelte'
 
 	/** @type {import('./$types').PageData} */
 	export let data;
 
-	let searchTerm = '';
-	let classList = data.classJson;
+	let archCategories = new Map(
+		[...data.classCategories].map(c => [c, false])
+	);
 
-	const classImages = import.meta.glob('$lib/images/*.{avif,gif,heif,jpeg,jpg,png,tiff,webp}', {
-		eager: true,
-		query: {
-			enhanced: true
-		}
-	});
+	const hoverColorVariants = {
+		Orientation: 'group-hover:bg-asmbly',
+		Woodworking: 'group-hover:bg-woodwork',
+		Metalworking: 'group-hover:bg-metalwork',
+		'Laser Cutting': 'group-hover:bg-lasers',
+		'3D Printing': 'group-hover:bg-3dprinting',
+		Textiles: 'group-hover:bg-textiles',
+		Electronics: 'group-hover:bg-electronics',
+		Miscellaneous: 'group-hover:bg-primary'
+	};
 
-	function getClassImage(className, category) {
-		const result = classImages['/src/lib/images/' + className.replace(/\s+/g, '_') + '.jpg'];
-
-		if (typeof result === 'undefined' || result === null) {
-			switch (category) {
-				case 'Orientation':
-				case 'Miscellaneous':
-					return classImages['/src/lib/images/classDefault.jpg'].default;
-				case 'Woodworking':
-					return classImages['/src/lib/images/woodworkingDefault.jpg'].default;
-				case 'Metalworking':
-					return classImages['/src/lib/images/metalworkingDefault.jpg'].default;
-				case 'Laser Cutting':
-					return classImages['/src/lib/images/lasersDefault.jpg'].default;
-				case '3D Printing':
-					return classImages['/src/lib/images/3dprintingDefault.jpg'].default;
-				case 'Textiles':
-					return classImages['/src/lib/images/textilesDefault.jpg'].default;
-				case 'Electronics':
-					return classImages['/src/lib/images/electronicsDefault.jpg'].default;
-				default:
-					return classImages['/src/lib/images/classDefault.jpg'].default;
-			}
-		}
-		return result.default;
-	}
-
-	$: archCategories = new Map([
-		['Orientation', false],
-		['Woodworking', false],
-		['Metalworking', false],
-		['Laser Cutting', false],
-		['3D Printing', false],
-		['Textiles', false],
-		['Electronics', false],
-		['Miscellaneous', false]
-	]);
-
-	function filterByCategory(classList, categoryMap) {
-		let allFalse = true;
-		let newClassList = [];
-		for (const [key, value] of categoryMap) {
-			if (value) {
-				const filtered = classList.filter((i) => i.category === key);
-				filtered.forEach((i) => newClassList.push(i));
-				allFalse = false;
-			}
-		}
-		newClassList = newClassList;
-		if (allFalse) {
-			return classList;
-		} else {
-			return newClassList;
-		}
-	}
-
-	function filterBySearch(classList, searchTerm) {
-		if (searchTerm !== '') {
-			const options = {
-				keys: ['name'],
-				threshold: 0.5
-			};
-			const fuse = new Fuse(classList, options);
-			const result = fuse.search(searchTerm);
-
-			const finalClassList = result.map((i) => i.item);
-			return finalClassList;
-		} else {
-			return classList;
-		}
-	}
-
-	const svgs = {
-		Orientation: [
-			'm122.16,77.71V0H0v44.44h20.85C9.16,51.21,1.05,63.5.1,77.71h-.1v5.59h.1c1.38,20.74,18.01,37.37,38.75,38.75v.1h5.59v-.1c14.22-.95,26.5-9.06,33.27-20.75v20.85h83.3v-44.44h-38.86Zm-5.59,0h-33.27v-33.27h33.27v33.27ZM44.44,44.44h33.27v33.27h-33.27v-33.27ZM83.3,5.59h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27H5.59V5.59Zm33.27,38.96v33.16H5.69c1.36-17.66,15.5-31.81,33.16-33.16ZM5.69,83.3h33.16v33.16c-17.66-1.36-31.81-15.5-33.16-33.16Zm38.75,33.16v-33.16h33.16c-1.36,17.66-15.5,31.81-33.16,33.16Zm72.13.11h-33.27v-33.27h33.27v33.27Zm38.86,0h-33.27v-33.27h33.27v33.27Z'
-		],
-		Woodworking: [
-			'm0,0v193.44h193.44V0H0Zm51.49,23.14h118.81v96.45c-23.1-52.93-64.23-86.24-118.81-96.45Zm106.81,147.17h-26.2c-4.79-57.18-50.68-99.4-108.97-100.3v-25.67c83.61,1.92,127.71,63.52,135.17,125.96ZM23.14,119.55v-26.25c45.51,2.4,77.73,31.46,85.42,77h-26.01c-6.31-30.61-28.17-49.28-59.4-50.76Zm35.26,50.76H23.14v-27.3c21.41,1.46,31.01,14.58,35.26,27.3Z'
-		],
-		Metalworking: [
-			'm0,0v194.99h195.73V0H0Zm171.23,170.55h-106.34v-61.19h28.82v-24.44h-53.32v85.62h-15.89V24.44h146.73v146.11Z',
-			'm109.83,115.31c4.78,1.97,10.05,1.97,14.83,0,.01,0,.02-.01.04-.02l31.07-12.82c4.46-1.84,4.46-8.14,0-9.98l-31.11-12.84h0c-4.78-1.97-10.04-1.97-14.82,0-4.78,1.97-8.5,5.68-10.48,10.44-1.98,4.76-1.98,10.01,0,14.77,1.98,4.76,5.7,8.47,10.48,10.44Z'
-		],
-		'Laser Cutting': [
-			'm0,0v193.81h193.82V0H0Zm84.95,71.65l-17.8-17.8-16.91,16.92,17.79,17.8h-25.21v23.92h25.21l-17.65,17.65,16.92,16.92,17.65-17.65v24.96h23.92v-24.96l17.92,17.92,16.91-16.92-17.91-17.92h25.25v-23.92h-25.25l18.06-18.06-16.92-16.91-18.06,18.06V23.92h61.02v145.97H23.92V23.92h61.02v47.72Z'
-		],
-		'3D Printing': [
-			'm0,0v194.82h194.82V0H0Zm25.11,52.48v-27.37h48.75l-48.75,27.37Zm144.6,28.14v89.09h-60.23v-53.32l60.23-35.77Zm-50.61-55.51h50.61v30.01l-50.61-30.01Zm-22.26,15.94l44.8,26.82-44.8,26.82-48.11-26.82,48.11-26.82Zm-12.47,75.43v53.24H25.11v-86.46l59.27,33.23Z'
-		],
-		Textiles: [
-			'm0,0v193.23h193.23V0H0Zm24.11,56.66V24.11h34.09v32.56H24.11Zm0,55.8v-31.69h34.09v31.69H24.11Zm0,56.66v-32.56h34.09v32.56H24.11Zm58.2-112.46V24.11h31.7v32.56h-31.7Zm0,55.8v-31.69h31.7v31.69h-31.7Zm0,56.66v-32.56h31.7v32.56h-31.7Zm55.8-112.46V24.11h31.02v32.56h-31.02Zm0,55.8v-31.69h31.02v31.69h-31.02Zm0,56.66v-32.56h31.02v32.56h-31.02Z'
-		],
-		Electronics: [
-			'm0,0v193.32h193.32V0H0Zm169.35,51.11h-74.72c-4.74-11.54-16.08-19.7-29.31-19.7-17.47,0-31.68,14.21-31.68,31.68s14.21,31.69,31.68,31.69c13.23,0,24.58-8.16,29.31-19.7h74.72v94.27h-66.61v-10.48l12.36-12.36c4.23,2.1,8.98,3.31,14.01,3.31,17.47,0,31.68-14.21,31.68-31.68s-14.21-31.69-31.68-31.69-31.68,14.21-31.68,31.69c0,3.63.65,7.11,1.78,10.37l-20.44,20.44v20.41H23.97V23.97h145.38v27.14Zm-96.32,11.99c0,4.26-3.46,7.71-7.71,7.71s-7.71-3.46-7.71-7.71,3.46-7.71,7.71-7.71,7.71,3.46,7.71,7.71Zm48.37,55.04c0-4.26,3.46-7.71,7.71-7.71s7.71,3.46,7.71,7.71-3.46,7.71-7.71,7.71-7.71-3.46-7.71-7.71Z'
-		],
-		Miscellaneous: [
-			'm122.16,77.71V0H0v44.44h20.85C9.16,51.21,1.05,63.5.1,77.71h-.1v5.59h.1c1.38,20.74,18.01,37.37,38.75,38.75v.1h5.59v-.1c14.22-.95,26.5-9.06,33.27-20.75v20.85h83.3v-44.44h-38.86Zm-5.59,0h-33.27v-33.27h33.27v33.27ZM44.44,44.44h33.27v33.27h-33.27v-33.27ZM83.3,5.59h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27h-33.27V5.59Zm-38.86,0h33.27v33.27H5.59V5.59Zm33.27,38.96v33.16H5.69c1.36-17.66,15.5-31.81,33.16-33.16ZM5.69,83.3h33.16v33.16c-17.66-1.36-31.81-15.5-33.16-33.16Zm38.75,33.16v-33.16h33.16c-1.36,17.66-15.5,31.81-33.16,33.16Zm72.13.11h-33.27v-33.27h33.27v33.27Zm38.86,0h-33.27v-33.27h33.27v33.27Z'
-		]
+	const checkedColorVariants = {
+		Orientation: 'bg-asmbly',
+		Woodworking: 'bg-woodwork',
+		Metalworking: 'bg-metalwork',
+		'Laser Cutting': 'bg-lasers',
+		'3D Printing': 'bg-3dprinting',
+		Textiles: 'bg-textiles',
+		Electronics: 'bg-electronics',
+		Miscellaneous: 'bg-primary'
 	};
 
 	function generateBackgroundColor(category, alwaysChecked = false) {
-		const baseColorVariants = {
-			Orientation: 'bg-base-300 group-hover:bg-asmbly',
-			Woodworking: 'bg-base-300 group-hover:bg-woodwork',
-			Metalworking: 'bg-base-300 group-hover:bg-metalwork',
-			'Laser Cutting': 'bg-base-300 group-hover:bg-lasers',
-			'3D Printing': 'bg-base-300 group-hover:bg-3dprinting',
-			Textiles: 'bg-base-300 group-hover:bg-textiles',
-			Electronics: 'bg-base-300 group-hover:bg-electronics',
-			Miscellaneous: 'bg-base-300 group-hover:bg-primary'
-		};
-
-		const checkedColorVariants = {
-			Orientation: 'group-hover:bg-asmbly bg-asmbly',
-			Woodworking: 'group-hover:bg-woodwork bg-woodwork',
-			Metalworking: 'group-hover:bg-metalwork bg-metalwork',
-			'Laser Cutting': 'group-hover:bg-lasers bg-lasers',
-			'3D Printing': 'group-hover:bg-3dprinting bg-3dprinting',
-			Textiles: 'group-hover:bg-textiles bg-textiles',
-			Electronics: 'group-hover:bg-electronics bg-electronics',
-			Miscellaneous: 'group-hover:bg-primary bg-primary'
-		};
-
+		let classList = [hoverColorVariants[category]]
 		if (archCategories.get(category) || alwaysChecked) {
-			return checkedColorVariants[category];
+			classList.push(checkedColorVariants[category]);
 		} else {
-			return baseColorVariants[category];
+			classList.push('bg-base-300')
 		}
-	}
 
-	function generateFillColor(category, alwaysChecked = false) {
-		const baseColorVariants = {
-			Orientation:
-				'fill-neutral group-hover:fill-asmbly-hover stroke-neutral group-hover:stroke-asmbly-hover',
-			Woodworking: 'fill-neutral group-hover:fill-woodwork-hover',
-			Metalworking: 'fill-neutral group-hover:fill-metalwork-hover',
-			'Laser Cutting': 'fill-neutral group-hover:fill-lasers-hover',
-			'3D Printing': 'fill-neutral group-hover:fill-3dprinting-hover',
-			Textiles: 'fill-neutral group-hover:fill-textiles-hover',
-			Electronics: 'fill-neutral group-hover:fill-electronics-hover',
-			Miscellaneous:
-				'fill-neutral group-hover:fill-asmbly-hover stroke-neutral group-hover:stroke-asmbly-hover'
-		};
-
-		const checkedColorVariants = {
-			Orientation:
-				'group-hover:fill-asmbly-hover fill-asmbly-hover stroke-asmbly-hover group-hover:stroke-asmbly-hover',
-			Woodworking: 'group-hover:fill-woodwork-hover fill-woodwork-hover',
-			Metalworking: 'group-hover:fill-metalwork-hover fill-metalwork-hover',
-			'Laser Cutting': 'group-hover:fill-lasers-hover fill-lasers-hover',
-			'3D Printing': 'group-hover:fill-3dprinting-hover fill-3dprinting-hover',
-			Textiles: 'group-hover:fill-textiles-hover fill-textiles-hover',
-			Electronics: 'group-hover:fill-electronics-hover fill-electronics-hover',
-			Miscellaneous:
-				'group-hover:fill-asmbly-hover fill-asmbly-hover stroke-asmbly-hover group-hover:stroke-asmbly-hover'
-		};
-
-		const alwaysCheckedVariants = {
-			Orientation: 'stroke-accent',
-			Woodworking: 'fill-woodwork',
-			Metalworking: 'fill-metalwork',
-			'Laser Cutting': 'fill-lasers',
-			'3D Printing': 'fill-3dprinting',
-			Textiles: 'fill-textiles',
-			Electronics: 'fill-electronics',
-			Miscellaneous: 'stroke-accent'
-		};
-
-		if (archCategories.get(category) && !alwaysChecked) {
-			return checkedColorVariants[category];
-		} else if (alwaysChecked) {
-			return alwaysCheckedVariants[category];
-		} else {
-			return baseColorVariants[category];
-		}
+		return classList.join(' ')
 	}
 
 	function toggleArchCategory(category) {
@@ -198,118 +48,23 @@
 		archCategories = archCategories;
 	}
 
-	function sortByName(classList) {
-		classList.sort((a, b) => {
-			const aName = a.name.toLowerCase();
-			const bName = b.name.toLowerCase();
-			if (aName < bName) {
-				return -1;
-			} else if (aName > bName) {
-				return 1;
-			} else {
-				return 0;
-			}
-		});
-		return classList;
-	}
-
-	function sortByDate(classList) {
-		classList.sort((a, b) => {
-			if (DateTime.fromJSDate(a.classInstances[0].startDateTime) < DateTime.local({zone: 'America/Chicago'})) {
-				return 1;
-			} else if (DateTime.fromJSDate(b.classInstances[0].startDateTime) < DateTime.local({zone: 'America/Chicago'})) {
-				return -1;
-			}
-			let sortedClassA = a.classInstances.sort((c1, c2) => {
-				if (c1.startDateTime < c2.startDateTime) {
-					return -1;
-				} else if (c1.startDateTime > c2.startDateTime) {
-					return 1;
-				} else {
-					return 0;
-				}
-			});
-			let sortedClassB = b.classInstances.sort((c1, c2) => {
-				if (c1.startDateTime < c2.startDateTime) {
-					return -1;
-				} else if (c1.startDateTime > c2.startDateTime) {
-					return 1;
-				} else {
-					return 0;
-				}
-			});
-			if (sortedClassA[0].startDateTime < sortedClassB[0].startDateTime) {
-				return -1;
-			} else if (sortedClassA[0].startDateTime > sortedClassB[0].startDateTime) {
-				return 1;
-			} else {
-				return 0;
-			}
-		});
-		return classList;
-	}
-
-	function sortByPrice(classList) {
-		classList.sort((a, b) => {
-			if (a.classInstances[0].price < b.classInstances[0].price) {
-				return -1;
-			} else if (a.classInstances[0].price > b.classInstances[0].price) {
-				return 1;
-			} else {
-				return 0;
-			}
-		});
-		return classList;
-	}
-
-	function sortBy(classList, sortByKeyword) {
-		if (sortByKeyword === 'Date') {
-			if (sortOrderKeyword === 'Asc') {
-				return sortByDate(classList);
-			} else {
-				return sortByDate(classList).reverse();
-			}
-		} else if (sortByKeyword === 'Name') {
-			if (sortOrderKeyword === 'Asc') {
-				return sortByName(classList);
-			} else {
-				return sortByName(classList).reverse();
-			}
-		} else if (sortByKeyword === 'Price') {
-			if (sortOrderKeyword === 'Asc') {
-				return sortByPrice(classList);
-			} else {
-				return sortByPrice(classList).reverse();
-			}
-		}
-	}
-
 	function sortClickHandler(keyword) {
-		sortByKeyword = keyword;
+		filters.sortBy = keyword;
 		document.getElementById('sortDropdown').removeAttribute('open');
 	}
 
 	function sortOrderHandler() {
-		if (sortOrderKeyword === 'Asc') {
-			sortOrderKeyword = 'Desc';
-		} else {
-			sortOrderKeyword = 'Asc';
-		}
+		filters.sortAsc = !filters.sortAsc
 	}
 
-	function clearSearch() {
-		searchTerm = '';
+	let filters = {
+		sortBy: 'Date',
+		sortAsc: true,
+		groupByClass: false,
+		showAll: false,
+		searchTerm: '',
 	}
 
-	let sortByKeyword = 'Date';
-	let sortOrderKeyword = 'Asc';
-
-	$: sortContent = 'Sort by: ' + sortByKeyword;
-	$: sortOrderContent = 'Order: ' + sortOrderKeyword;
-
-	$: sortedClassList = sortBy(classList, sortByKeyword, sortOrderKeyword);
-
-	$: finalClassList = filterBySearch(filterByCategory(sortedClassList, archCategories), searchTerm);
 </script>
 
 <svelte:head>
@@ -337,8 +92,7 @@
 									stroke-linejoin="round"
 									stroke-width="2"
 									viewBox="0 0 24 24"
-									class="h-6 w-6"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg
-								>
+									class="h-6 w-6"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
 							</button>
 						</span>
 						<input
@@ -347,13 +101,29 @@
 							class="my-2 w-full bg-base-300 py-2 pl-10 text-sm text-neutral placeholder:italic placeholder:text-neutral focus:bg-secondary focus:text-secondary-content focus:outline-none"
 							placeholder="Search by class name..."
 							autocomplete="off"
-							bind:value={searchTerm}
+							bind:value={filters.searchTerm}
 						/>
 					</div>
 					<div class="row-start-2 flex justify-center">
+						<div>
+							<button on:click={() => filters.groupByClass = !filters.groupByClass} class="btn btn-ghost rounded-none lg:ml-2"
+								>Group By: {filters.groupByClass ? 'Class Type' : 'Date'}
+								<svg
+									fill="none"
+									viewBox="0 0 20 20"
+									class="h-4 w-4 transform transition-transform duration-200"
+									><path
+										class="fill-base-content"
+										fill-rule="evenodd"
+										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+										clip-rule="evenodd"
+									/></svg
+								>
+							</button>
+						</div>
 						<details id="sortDropdown" class="dropdown">
 							<summary class="btn btn-ghost rounded-none lg:ml-2"
-								>{sortContent}
+								>Sort by: {filters.sortBy}
 								<svg
 									fill="none"
 									viewBox="0 0 20 20"
@@ -366,6 +136,7 @@
 									/></svg
 								>
 							</summary>
+
 							<ul
 								class="menu dropdown-content z-[1] w-40 rounded-none bg-base-100 p-2 shadow-xl"
 							>
@@ -378,7 +149,22 @@
 						</details>
 						<div>
 							<button on:click={() => sortOrderHandler()} class="btn btn-ghost rounded-none lg:ml-2"
-								>{sortOrderContent}
+								>Order: {filters.sortAsc ? 'Asc' : 'Desc'}
+								<svg
+									fill="none"
+									viewBox="0 0 20 20"
+									class="h-4 w-4 transform transition-transform duration-200 {filters.sortAsc ? 'rotate-180' : ''}"
+									><path
+										class="fill-base-content"
+										fill-rule="evenodd"
+										d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+										clip-rule="evenodd"
+									/></svg
+								>
+							</button>
+						</div>
+						<div>
+							<button on:click={() => filters.showAll = !filters.showAll} class="btn btn-ghost rounded-none lg:ml-2">{filters.showAll ? 'Hide Unavailable' : 'Show Unavailable'}
 								<svg
 									fill="none"
 									viewBox="0 0 20 20"
@@ -415,88 +201,7 @@
 						<span class="">Show Filters</span>
 					</label>
 				</div>
-				{#each finalClassList as event}
-					<div class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:max-h-80">
-						<figure class="w-full lg:w-4/5">
-							<enhanced:img
-								class="h-full"
-								src={getClassImage(event.name, event.category)}
-								alt="{event.name} image"
-							/>
-						</figure>
-						<div class="card-body w-full">
-							<div class="flex justify-between">
-								<h2 class="font-asmbly text-accent card-title font-light">{event.name}</h2>
-								<div class="grid h-8 w-8 place-items-center">
-									<svg
-										fill="none"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										viewBox={event.category === 'Miscellaneous' || event.category === 'Orientation'
-											? '-7.5 0 175 100'
-											: '0 0 195 195'}
-										class="h-6 w-6"
-									>
-										{#each svgs[event.category] as svgPath}
-											<path
-												stroke-width={event.category === 'Miscellaneous' ||
-												event.category === 'Orientation'
-													? '6'
-													: '2.5'}
-												class={generateFillColor(event.category, true)}
-												d={svgPath}
-											/>
-										{/each}
-									</svg>
-								</div>
-							</div>
-							<p class="text-lg">Next Class: <b>
-								{event.classInstances[0].startDateTime.toLocaleString('en-US', {dateStyle: "short", timeStyle: "short"})}
-							</b></p>
-							{#if event.classInstances[0].summary}
-							<p class="text-md">
-								{event.classInstances[0].summary.length > 200
-									? event.classInstances[0].summary.substring(0, 200) + '...'
-									: event.classInstances[0].summary}
-							</p>
-							{:else}
-							<p class="text-md">No summary available</p>
-							{/if}
-							<div class="card-actions content-center justify-end">
-								<p>Price: {event.classInstances[0].price === 0 ? 'Free' : '$' + event.classInstances[0].price + '.00'}</p>
-								<a class="btn btn-primary rounded-none" href="/event/{event.typeId}">Learn More</a>
-							</div>
-						</div>
-					</div>
-				{/each}
-				{#if finalClassList.length === 0}
-					<div
-						class="card mx-2 mb-4 rounded-none bg-base-100 shadow-xl lg:card-side lg:mr-64 lg:max-h-64"
-					>
-						<figure class="h-64 w-full lg:w-4/5">
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 -960 960 960"
-								class="h-full w-full fill-base-content"
-								><path
-									d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"
-								/></svg
-							>
-						</figure>
-						<div class="card-body w-full">
-							<h2 class="font-asmbly text-accent card-title font-light">Sorry, no results found</h2>
-							<p class="text-md">
-								We couldn't find any classes that match your search. Try adjusting your filters or
-								checking your spelling.
-							</p>
-							<div class="card-actions content-center justify-end">
-								<button on:click={() => clearSearch()} class="btn btn-primary rounded-none"
-									>Clear Search</button
-								>
-							</div>
-						</div>
-					</div>
-				{/if}
+				<ClassList classJson={data.classJson} filters={filters} categoryMap={archCategories}/>
 			</div>
 		</div>
 	</div>
@@ -518,28 +223,7 @@
 										category
 									)} h-8 w-8 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.10)] group-hover:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.2)]"
 								>
-									<svg
-										fill="none"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width={category === 'Miscellaneous' || category === 'Orientation'
-											? '5'
-											: '2.5'}
-										viewBox={category === 'Miscellaneous' || category === 'Orientation'
-											? '-7.5 0 175 100'
-											: '0 0 195 195'}
-										class="h-4 w-4"
-									>
-										{#each svgs[category] as svgPath}
-											<path
-												stroke-width={category === 'Miscellaneous' || category === 'Orientation'
-													? '8'
-													: '2.5'}
-												class={generateFillColor(category)}
-												d={svgPath}
-											/>
-										{/each}
-									</svg>
+								<AsmblyIcon category={category} checked={archCategories.get(category)} />
 								</div>
 								<span class="label-text group-hover:text-base-content/60">{category}</span>
 							</div>

--- a/app/src/routes/(data-pages)/event/[eventTypeId]/+page.server.js
+++ b/app/src/routes/(data-pages)/event/[eventTypeId]/+page.server.js
@@ -3,6 +3,8 @@ import { superValidate, message } from 'sveltekit-superforms/server';
 import { schema, privateRequestSchema } from '$lib/zodSchemas/schema.js';
 import { prisma } from '$lib/postgres.js';
 import { sendMIMEmessage } from '$lib/server/gmailEmailFactory.js';
+import NeonEventType from '$lib/models/neonEventType.js'
+
 import { DateTime } from 'luxon';
 
 /** @type {import('./$types').PageServerLoad} */
@@ -69,61 +71,35 @@ export async function load({ params, setHeaders }) {
 		throw error(404, 'Event not found');
 	}
 
-	if (!eventType.instances.length) {
-		eventType = await prisma.neonEventType.findUnique({
+	const eventModel = NeonEventType.fromPrisma(eventType)
+	if (eventType.instances.length) {
+		eventModel.addInstances(...eventType.instances)
+	} else {
+		const instance = await prisma.neonEventInstance.findFirst({
 			where: {
-				id: parseInt(params.eventTypeId)
-			},
-			include: {
+				eventTypeId: parseInt(params.eventTypeId),
 				category: {
-					include: {
-						archCategories: true
+					isNot: {
+						name: 'Private'
 					}
 				},
-				instances: {
-					where: {
-						category: {
-							isNot: {
-								name: 'Private'
-							}
-						}
-					},
-					orderBy: {
-						startDateTime: 'desc'
-					},
-					take: 1,
-					include: {
-						teacher: {
-							select: {
-								name: true
-							}
-						}
+			},
+			orderBy: {
+				startDateTime: 'asc'
+			},
+			include: {
+				teacher: {
+					select: {
+						name: true
 					}
 				}
 			}
-		})
+		});
+
+		eventModel.addInstances(instance)
 	}
 
-	const classJson = {};
-
-	let classInstances = [];
-	for (const instance of eventType.instances) {
-		const instanceContext = {};
-		instanceContext.eventId = instance.eventId;
-		instanceContext.attendees = instance.attendeeCount;
-		instanceContext.teacher = instance.teacher.name;
-		instanceContext.startDateTime = instance.startDateTime;
-		instanceContext.endDateTime = instance.endDateTime;
-		instanceContext.summary = instance.summary;
-		instanceContext.price = instance.price;
-		instanceContext.capacity = instance.capacity;
-		classInstances.push(instanceContext);
-	}
-
-	classJson.classInstances = classInstances;
-	classJson.name = eventType.name;
-	classJson.category = eventType.category[0].archCategories.name;
-	classJson.typeId = eventType.id;
+	const classJson = eventModel.toJson()
 
 	// Unless you throw, always return { form } in load and form actions.
 	return { privateRequestForm, notificationForm, onDemandRequestForm, fullClassRequestForm, classJson, baseRegLink };

--- a/app/src/routes/(data-pages)/event/[eventTypeId]/+page.svelte
+++ b/app/src/routes/(data-pages)/event/[eventTypeId]/+page.svelte
@@ -5,6 +5,7 @@
 	import { DateTime } from 'luxon';
 	import { page } from '$app/stores';
 
+	import NeonEventType from '$lib/models/neonEventType.js'
 	import SuperForm from '$lib/components/classRequestForm.svelte';
 	import TextField from '$lib/components/textField.svelte';
 	import RadioField from '$lib/components/radioField.svelte';
@@ -18,34 +19,29 @@
 			await tick();
 			window.scrollTo(0, 0);
 		}
+
+		const el = document.getElementById(classInstanceId);
+		el?.scrollIntoViewIfNeeded({
+      behavior: 'smooth'
+    });
 	});
 
 	const noCheckouts = ['Beginner CNC Router', 'Big Lasers Class', 'Small Lasers Class', 'Woodshop Safety', 'Metal Shop Safety'];
 
-	$: classType = data.classJson;
-
-	$: classInstances = classType.classInstances.map(i => {
-		return {
-			...i,
-			startDateTime: DateTime.fromJSDate(i.startDateTime),
-			endDateTime: DateTime.fromJSDate(i.endDateTime)
-		}
-	});
-
-	$: classDates = classInstances.map(i => i.startDateTime);
+	$: classType = new NeonEventType(data.classJson);
 
 	$: classInstanceId = $page.url.searchParams.get('eventId')
 
-	$: date = (classInstanceId && classInstances.find(i => i.eventId == classInstanceId)?.startDateTime) || classDates[0] || DateTime.now()
+	$: classInstance = (classInstanceId && classType.classInstances.find(i => i.eventId == classInstanceId)) || classType.classInstances[0]
 
-	function classDateUrl(date) {
-		const classOnDay = classInstances.find(i => i.startDateTime.hasSame(date, 'day'))
+	$: date = classInstance.startDateTime || DateTime.now()
+
+	$: classDates = classType.classInstances.map(i => i.startDateTime);
+
+	function classDayUrl(day) {
+		const classOnDay = classType.classInstances.find(i => i.startDateTime.hasSame(day, 'day'))
 		return `?eventId=${classOnDay.eventId}`
 	}
-
-	$: classOnDate = classInstances.find((i) =>
-		i.startDateTime.hasSame(date, 'day')
-	);
 
 </script>
 
@@ -63,130 +59,155 @@
 	>
 		{classType.name}
 	</h1>
-	<div class="card mt-2 flex lg:w-full max-w-6xl justify-center rounded-none shadow-lg lg:card-side lg:min-h-[540px]">
-		<div class="rounded p-5 md:p-8">
-			<Calendar selectedDate={date} toUrl={classDateUrl} highlightedDates={classDates}/>
-		</div>
-		<div class="divider mx-6 lg:divider-horizontal lg:mx-0 lg:my-8" />
-		<div class="flex flex-col px-5 py-5 md:px-8 md:py-8">
-			{#if classInstances.length > 0}
-			<div class="px-4">
-				<h2 class="pb-4 text-lg font-semibold">{date.toFormat("cccc', 'LLLL d")}</h2>
-				<div class="flex w-72 justify-between lg:w-96">
-					<div class="border-base-300 pb-4 lg:pb-0">
-						<p class="text-md font-light leading-3">
-							{classOnDate.startDateTime.toLocaleString(DateTime.TIME_SIMPLE)} - {
-								classOnDate.endDateTime.toLocaleString(DateTime.TIME_SIMPLE)}
-						</p>
-						<p class="pt-2 text-md leading-none">Teacher: {classOnDate.teacher}</p>
-						<p class="pt-2 text-md leading-none">
-							Capacity: {classOnDate.capacity}
-						</p>
-						<p class="pt-2 text-md leading-none">Attendees: <span class:text-error={classOnDate.attendees === classOnDate.capacity}>{classOnDate.attendees}</span></p>
-						<p class="pt-2 text-md leading-none">
-							Price: {classOnDate.price === 0 ? 'Free' : '$' + classOnDate.price + '.00'}
-						</p>
-					</div>
-					<div class="flex items-center justify-end pb-4 lg:pb-0">
-						{#if classOnDate.attendees < classOnDate.capacity}
-							<a
-								class="btn btn-primary rounded-none"
-								href={data.baseRegLink.url + classOnDate.eventId}
-								target="_blank">Register</a
-							>
-						{:else if classOnDate.attendees === classOnDate.capacity}
-						<div class="flex flex-col items-center justify-center">
-							<button
-								class="btn btn-primary rounded-none"
-								on:click={() => document.getElementById('fullClassNotification').showModal()}
-								>Join the Waitlist</button
-							>
-							<dialog id="fullClassNotification" class="modal">
-								<div class="modal-box rounded-none">
-									
-										<button
-											class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2 rounded-none"
-											on:click={() => document.getElementById('fullClassNotification').close()}
-											>✕</button
-										>
-									
-									<!-- Modal content -->
-
-									<div class="prose">
-										<h2 class="font-asmbly">Notify me</h2>
-										<p>
-											Sign up below to receive an email if a seat opens up in this session of the
-											class.
-										</p>
-									</div>
-
-									<SuperForm
-										action="?/fullClassRequest"
-										data={data?.fullClassRequestForm}
-										dataType="form"
-										invalidateAll={false}
-										validators={schema}
-										eventId={classOnDate.eventId}
-										let:form
-										let:message
-										let:delayed
-									>
-										{#if message}
-											<div
-												class="status {message.status >= 400 ? 'text-error' : ''} {message.status <
-													300 || !message.status
-													? 'text-success'
-													: ''}"
-											>
-												{message.text}
-											</div>
-										{/if}
-										<TextField
-											type="text"
-											{form}
-											field="firstName"
-											label="First Name"
-											class="w-full"
-										/>
-										<TextField
-											type="text"
-											{form}
-											field="lastName"
-											label="Last Name"
-											class="w-full"
-										/>
-										<TextField
-											type="email"
-											{form}
-											field="email"
-											label="Email"
-											class="mb-4 w-full"
-											autocomplete="email"
-										/>
-
-										<p class="flex">
-											<button class="btn btn-primary mb-2 mt-4 rounded-none mr-2" type="submit"
-												>Submit</button
-											>
-											{#if delayed}
-											<span class="loading loading-spinner loading-md "></span>
-											{/if}
-										</p>
-									</SuperForm>
-
-									<!-- End Modal content -->
-								</div>
-								<form method="dialog" class="modal-backdrop">
-									<button>close</button>
-								</form>
-							</dialog>
-						</div>
-						{/if}
-					</div>
+	<div class="drawer mt-2 flex lg:w-full max-w-6xl justify-center rounded-none shadow-lg max-lg:drawer-end lg:drawer-open lg:min-h-[540px]">
+		<input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+		<div class="drawer-side lg:h-auto z-10">
+			<label for="my-drawer-2" aria-label="close calendar" class="drawer-overlay" />
+			<div class="flex">
+				<div class="bg-base-100">
+					<Calendar selectedDate={date} classInstances={classType.classInstances}/>
 				</div>
+				<div class="lg:divider lg:divider-horizontal lg:mx-0 lg:my-8" />
 			</div>
-			{:else}
-			<div class="px-4">
+		</div>
+		<div class="drawer-content flex flex-col px-5 py-5 md:px-8 md:py-8">
+			<div class="fixed right-4 top-40 lg:hidden">
+					<label
+						for="my-drawer-2"
+						class="btn btn-primary drawer-button btn-circle drop-shadow-lg"
+					>
+					<span class="material-symbols-outlined">calendar_month</span>
+					</label>
+			</div>
+			<div class="max-w-md px-4">
+				<div>
+					<h2 class="pb-4 text-lg font-semibold">Description</h2>
+					<p class="xs:prose-sm lg:prose-md">{classInstance.summary || classType.summary || 'No description available.'}</p>
+				</div>
+				<div class="divider" />
+				<div class="flex justify-between text-md leading-none">
+					<p>
+						<span class="font-semibold">Price:</span> {classInstance.price === 0 ? 'Free' : '$' + classInstance.price + '.00'}
+					</p>
+					<p>
+						<span class="font-semibold">Capacity:</span> {classInstance.capacity}
+					</p>
+				</div>
+				<div class="divider" />
+				{#if classType.anyCurrent}
+				<div class="lg:max-h-60 overflow-auto scroll-smooth">
+					{#each classType.classInstances as instance}
+					<div class="{instance.eventId === classInstance.eventId ? 'bg-primary/20 hover:bg-primary/30' : 'hover:bg-primary/10'} p-4" id="{instance.eventId}">
+						<h2 class="mb-2 text-lg"><span class="font-semibold">{instance.startDateTime.toFormat("cccc', 'LLLL d")}</span><span class="font-light"> &nbsp;at
+							{instance.startDateTime.toLocaleString(DateTime.TIME_SIMPLE)} - {
+											instance.endDateTime.toLocaleString(DateTime.TIME_SIMPLE)}
+						</span></h2>
+						<div class="flex justify-between">
+							<div class="border-base-300 pb-4 lg:pb-0">
+								<p class="pt-2 text-md leading-none"><span class="font-bold">Teacher:</span> {instance.teacher}</p>
+								<p class="pt-2 text-md leading-none"><span class="font-bold">Attendees:</span> <span class:text-error={instance.attendees === instance.capacity}>{instance.attendees}</span></p>
+							</div>
+							<div class="flex items-center justify-end pb-4 lg:pb-0">
+								{#if instance.attendees < instance.capacity}
+									<a
+										class="btn btn-primary rounded-none"
+										href={data.baseRegLink.url + instance.eventId}
+										target="_blank">Register</a
+									>
+								{:else if instance.attendees === instance.capacity}
+								<div class="flex flex-col items-center justify-center">
+									<button
+										class="btn btn-primary rounded-none"
+										on:click={() => document.getElementById('fullClassNotification').showModal()}
+										>Join the Waitlist</button
+									>
+									<dialog id="fullClassNotification" class="modal">
+										<div class="modal-box rounded-none">
+
+												<button
+													class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2 rounded-none"
+													on:click={() => document.getElementById('fullClassNotification').close()}
+													>✕</button
+												>
+
+											<!-- Modal content -->
+
+											<div class="prose">
+												<h2 class="font-asmbly">Notify me</h2>
+												<p>
+													Sign up below to receive an email if a seat opens up in this session of the
+													class.
+												</p>
+											</div>
+
+											<SuperForm
+												action="?/fullClassRequest"
+												data={data?.fullClassRequestForm}
+												dataType="form"
+												invalidateAll={false}
+												validators={schema}
+												eventId={instance.eventId}
+												let:form
+												let:message
+												let:delayed
+											>
+												{#if message}
+													<div
+														class="status {message.status >= 400 ? 'text-error' : ''} {message.status <
+															300 || !message.status
+															? 'text-success'
+															: ''}"
+													>
+														{message.text}
+													</div>
+												{/if}
+												<TextField
+													type="text"
+													{form}
+													field="firstName"
+													label="First Name"
+													class="w-full"
+												/>
+												<TextField
+													type="text"
+													{form}
+													field="lastName"
+													label="Last Name"
+													class="w-full"
+												/>
+												<TextField
+													type="email"
+													{form}
+													field="email"
+													label="Email"
+													class="mb-4 w-full"
+													autocomplete="email"
+												/>
+
+												<p class="flex">
+													<button class="btn btn-primary mb-2 mt-4 rounded-none mr-2" type="submit"
+														>Submit</button
+													>
+													{#if delayed}
+													<span class="loading loading-spinner loading-md "></span>
+													{/if}
+												</p>
+											</SuperForm>
+
+											<!-- End Modal content -->
+										</div>
+										<form method="dialog" class="modal-backdrop">
+											<button>close</button>
+										</form>
+									</dialog>
+								</div>
+								{/if}
+							</div>
+						</div>
+					</div>
+					{/each}
+				</div>
+				{:else}
 				<h2 class="pb-4 text-lg font-semibold">No sessions currently scheduled</h2>
 				<div class="flex w-72 justify-between lg:w-96">
 					<div class="border-base-300 pb-4 lg:pb-0">
@@ -280,99 +301,90 @@
 
 					</div>
 				</div>
-			</div>
-			{/if}
-			<div class="ml-4 divider" />
-			<div class="max-w-md px-4">
-				<h2 class="pb-4 text-lg font-semibold">Description</h2>
-				{#if classOnDate}
-				<p class="xs:prose-sm lg:prose-md">{classOnDate.summary ? classOnDate.summary : 'No description available.'}</p>
-				{:else}
-				<p class="xs:prose-sm lg:prose-md">{classInstances[0].summary}</p>
 				{/if}
 			</div>
-			{#if classType.category !== 'Orientation' && classInstances[0].startDateTime > DateTime.local({zone: 'America/Chicago'})}
-				<div class="flex max-w-md justify-between px-4 pt-4">
-					<button class="btn btn-primary rounded-none" on:click={() => document.getElementById('privateAndCheckout').showModal()}>
-						Request a Private or Checkout Session</button
-					>
-					<dialog id="privateAndCheckout" class="modal">
-						<div class="modal-box rounded-none">
-							
-								<button class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2 rounded-none"
-									on:click={() => document.getElementById('privateAndCheckout').close()}
-									>✕</button
-								>
-							
-							<!-- Modal content -->
+			{#if classType.category !== 'Orientation' && classType.classInstances[0].startDateTime > DateTime.local({zone: 'America/Chicago'})}
+			<div class="flex max-w-md justify-between px-4 mt-12">
+				<button class="btn btn-primary rounded-none" on:click={() => document.getElementById('privateAndCheckout').showModal()}>
+					Request a Private or Checkout Session</button
+				>
+				<dialog id="privateAndCheckout" class="modal">
+					<div class="modal-box rounded-none">
 
-							<div class="prose">
-								<h2 class="font-asmbly">Private/Checkout Class Request</h2>
-								<p>
-									Sign up below to request a private or checkout session. Note that we do not offer
-									checkout sessions for all classes. This will be indicated by a disabled "Checkout"
-									option. More info about private and checkout classes can be found in our <a
-										href="/classes-faq">Classes FAQ</a
-									>.
-								</p>
-							</div>
-
-							<SuperForm
-								action="?/privateRequest"
-								data={data?.privateRequestForm}
-								dataType="form"
-								invalidateAll={false}
-								validators={privateRequestSchema}
-								classTypeId={$page.params.eventTypeId}
-								let:form
-								let:message
-								let:delayed
+							<button class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2 rounded-none"
+								on:click={() => document.getElementById('privateAndCheckout').close()}
+								>✕</button
 							>
-								{#if message}
-									<div
-										class="status {message.status >= 400 ? 'text-error' : ''} {message.status <
-											300 || !message.status
-											? 'text-success'
-											: ''}"
-									>
-										{message.text}
-									</div>
-								{/if}
-								<TextField type="text" {form} field="firstName" label="First Name" class="w-full" />
-								<TextField type="text" {form} field="lastName" label="Last Name" class="w-full" />
-								<TextField type="email" {form} field="email" label="Email" class="mb-4 w-full" autocomplete="email" />
 
-								<RadioField
-									{form}
-									field="sessionType"
-									options={['Private', 'Checkout']}
-									class="my-4 ml-2 radio radio-accent"
-									{noCheckouts}
-									className={classType.name}
-								/>
+						<!-- Modal content -->
 
-								<p class="flex">
-									<button class="btn btn-primary mb-2 mt-4 rounded-none mr-2" type="submit"
-										>Submit</button
-									>
-									{#if delayed}
-									<span class="loading loading-spinner loading-md "></span>
-									{/if}
-								</p>
-							</SuperForm>
-
-							<!-- End Modal content -->
+						<div class="prose">
+							<h2 class="font-asmbly">Private/Checkout Class Request</h2>
+							<p>
+								Sign up below to request a private or checkout session. Note that we do not offer
+								checkout sessions for all classes. This will be indicated by a disabled "Checkout"
+								option. More info about private and checkout classes can be found in our <a
+									href="/classes-faq">Classes FAQ</a
+								>.
+							</p>
 						</div>
-						<form method="dialog" class="modal-backdrop">
-							<button>close</button>
-						</form>
-					</dialog>
-				</div>
+
+						<SuperForm
+							action="?/privateRequest"
+							data={data?.privateRequestForm}
+							dataType="form"
+							invalidateAll={false}
+							validators={privateRequestSchema}
+							classTypeId={$page.params.eventTypeId}
+							let:form
+							let:message
+							let:delayed
+						>
+							{#if message}
+								<div
+									class="status {message.status >= 400 ? 'text-error' : ''} {message.status <
+										300 || !message.status
+										? 'text-success'
+										: ''}"
+								>
+									{message.text}
+								</div>
+							{/if}
+							<TextField type="text" {form} field="firstName" label="First Name" class="w-full" />
+							<TextField type="text" {form} field="lastName" label="Last Name" class="w-full" />
+							<TextField type="email" {form} field="email" label="Email" class="mb-4 w-full" autocomplete="email" />
+
+							<RadioField
+								{form}
+								field="sessionType"
+								options={['Private', 'Checkout']}
+								class="my-4 ml-2 radio radio-accent"
+								{noCheckouts}
+								className={classType.name}
+							/>
+
+							<p class="flex">
+								<button class="btn btn-primary mb-2 mt-4 rounded-none mr-2" type="submit"
+									>Submit</button
+								>
+								{#if delayed}
+								<span class="loading loading-spinner loading-md "></span>
+								{/if}
+							</p>
+						</SuperForm>
+
+						<!-- End Modal content -->
+					</div>
+					<form method="dialog" class="modal-backdrop">
+						<button>close</button>
+					</form>
+				</dialog>
+			</div>
 			{/if}
-			{#if classInstances[0].startDateTime > DateTime.local({zone: 'America/Chicago'})}
+			{#if classType.classInstances[0].startDateTime > DateTime.local({zone: 'America/Chicago'})}
 			<div class="flex max-w-md justify-between p-4">
 				<button
-					class="btn btn-ghost btn-sm rounded-none text-sm font-light"
+					class="btn btn-outline btn-sm rounded-none text-sm font-light"
 					on:click={() => document.getElementById('classNotify').showModal()}>Notify me when additional sessions are added</button
 				>
 				<dialog id="classNotify" class="modal">
@@ -436,8 +448,8 @@
 				</dialog>
 			</div>
 			{/if}
-		</div>
 	</div>
+</div>
 </div>
 
 <style>

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -9,12 +9,24 @@
 	import NewsletterEmail from '$lib/components/newsletterEmail.svelte';
 	import { newsletterSchema } from '$lib/zodSchemas/schema.js';
 	import { browser } from '$app/environment';
+	import { afterNavigate } from '$app/navigation'
 
 	export let data;
 
 	let isDarkMode;
 	let themeSelection = 'system';
 	let details;
+	let prevPage = 'https://asmbly.org'
+
+	afterNavigate(nav => {
+		if (nav.to.url.pathname === '/') {
+			prevPage = 'https://asmbly.org'
+		} else if (nav.from) {
+			prevPage = nav.from.url.href
+		} else {
+			prevPage = '/'
+		}
+	})
 
 	if (browser) {
 		isDarkMode = document.documentElement.getAttribute('data-theme') === 'asmblyDark';
@@ -70,7 +82,7 @@
 		<div class="navbar-start w-full lg:w-1/2">
 			<a
 				class="btn btn-ghost hidden rounded-none lg:flex"
-				href={$page.url.pathname === '/' ? 'https://asmbly.org' : '/'}
+				href={prevPage}
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 		if (nav.to.url.pathname === '/') {
 			prevPage = 'https://asmbly.org'
 		} else if (nav.from) {
-			prevPage = nav.from.url.href
+			if (nav.from.url.pathname !== nav.to.url.pathname) prevPage = nav.from.url.href
 		} else {
 			prevPage = '/'
 		}

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -57,7 +57,8 @@ export default {
 					secondary: asmblyWhite,
 					accent: colors.asmbly.DEFAULT,
 					neutral: '#3d4451',
-					'base-100': asmblyWhite
+					'base-100': asmblyWhite,
+					'--rounded-btn': 0
 				}
 			},
 			{
@@ -66,7 +67,8 @@ export default {
 					secondary: asmblyWhite,
 					accent: asmblyWhite,
 					neutral: '#7c879c',
-					'base-100': '#3d4451'
+					'base-100': '#3d4451',
+					'--rounded-btn': 0
 				}
 			}
 		]


### PR DESCRIPTION
I'm still documenting, but wanted to submit so you could see where I was headed and let me know if it makes sense.

UI changes on class list page:

- All filtering and search happens in the drawer
- New Filters options:
  - Group By Class Type (default false)
  - Show Unavailable Classes (default false)
  - Compact/Comfy Spacing (default comfy)
- When classes are not grouped by type, clicking on the link to a class instance will take you to the class type page and highlight the class date you clicked on

UI changes on class: instance view

- All class instances are listed in date order underneath the description, price and capacity of the class.
- Full classes are 50% opacity on the calendar
- Calendar is now in a drawer so that it hides on mobile view. Drawer can be opened by pressing the calendar button that floats on the right side of the screen.
- Selecting a class date on the calendar will scroll that class instance into view and highlight it.

Major Code Changes:

- Added model classes for `NeonEventType` and `NeonEventInstance`
- Increased use of components in views
- Use URL params to persist search/filter state, control which class instance is being shown