### PR TITLE
Set austin timezone when loading events

### DIFF
--- a/app/src/lib/models/neonEventInstance.js
+++ b/app/src/lib/models/neonEventInstance.js
@@ -5,8 +5,8 @@ export default class NeonEventInstance {
 		this.eventId = instance.eventId
 		this.attendees = instance.attendeeCount || instance.attendees || 0
 		this.teacher = instance.teacher.name || instance.teacher
-		this.startDateTime = DateTime.fromJSDate(instance.startDateTime)
-		this.endDateTime = DateTime.fromJSDate(instance.endDateTime)
+		this.startDateTime = DateTime.fromJSDate(instance.startDateTime).setZone("America/Chicago")
+		this.endDateTime = DateTime.fromJSDate(instance.endDateTime).setZone("America/Chicago")
 		this.price = instance.price
 		this.summary = instance.summary
 		this.capacity = instance.capacity


### PR DESCRIPTION
Address #16 

Testplan:
1/ Host website locally 
```
cd app && npm install
DATABASE_URL="..." npm run dev
```

The value of `DATABASE_URL` was obtained by running `aws ssm get-parameter --name "..." --with-decryption` where the `name` is the value for the `DATABASE_URL` key in the app runner configeration tab.

2/ Verify that the times on the event list and event details page looks correct

In browser dev tools, set location to Berlin
Before, times shown the Berlin timezone: [class list](https://drive.google.com/file/d/1cVaIPdPYpZRN4x4-_F5wXTdm6emijz55/view?usp=drive_link), [class details](https://drive.google.com/file/d/1J-DTKSQNwFxAM39qwmERzztnItr4YHtH/view?usp=drive_link)
After, shown in the Austin timezone (and still in the locale style): [class list](https://drive.google.com/file/d/1pghIz396UxI_Id-D6JXQ8g1D4i-cOr2g/view?usp=drive_link), [class details](https://drive.google.com/file/d/1_n3GSag55kHmXg5hFPqa7sggfrYj9ZVm/view?usp=drive_link)