### PR TITLE
Disable waitlist for Orientation classes

### DIFF
--- a/app/src/routes/(data-pages)/event/[eventTypeId]/+page.svelte
+++ b/app/src/routes/(data-pages)/event/[eventTypeId]/+page.svelte
@@ -138,6 +138,9 @@
 												<span class:text-lasers={instance.attendees === instance.capacity}
 													>{instance.attendees}</span
 												>
+												{#if instance.attendees === instance.capacity && classType.category === 'Orientation'}
+													<span class="font-semibold"> (Class Full)</span>
+												{/if}
 											</p>
 										</div>
 										<div class="flex items-center justify-end pb-4 lg:pb-0">
@@ -147,6 +150,8 @@
 													href={data.baseRegLink.url + instance.eventId}
 													target="_blank">Register</a
 												>
+											{:else if instance.attendees === instance.capacity && classType.category === 'Orientation'}
+												<!-- No waitlist for Orientation classes -->
 											{:else if instance.attendees === instance.capacity}
 												<div class="flex flex-col items-center justify-center">
 													<button


### PR DESCRIPTION
Show "(Class Full)" next to attendee count and hide the waitlist button for Orientation classes when at capacity. Fixes #25.

### Testplan: 

Host with
```
% cd app && DATABASE_URL="..." npm run dev 
```

Before:
<img width="1822" height="1180" alt="Screenshot 2026-02-02 at 8 15 27 PM" src="https://github.com/user-attachments/assets/0c0366eb-046e-4a4d-bad8-11d74ab597cb" />

After:
<img width="1822" height="1180" alt="Screenshot 2026-02-02 at 8 15 25 PM" src="https://github.com/user-attachments/assets/9523026a-14d8-4004-8a85-f2d6d38419e6" />
