### PR TITLE
add pagination to fix sync issue

### DIFF
--- a/app/src/lib/helpers/neonHelpers.js
+++ b/app/src/lib/helpers/neonHelpers.js
@@ -40,7 +40,7 @@ async function* postEventSearch(searchFields, outputFields) {
 }
 
 async function getActualAttendees(eventId) {
-	const resourcePath = `/v2/events/${eventId}/eventRegistrations`;
+	const resourcePath = `/v2/events/${eventId}/eventRegistrations?pageSize=200`;
 	const httpVerb = 'GET';
 	const url = N_BASE_URL + resourcePath;
 

--- a/cron-service/prisma/neonHelpers.js
+++ b/cron-service/prisma/neonHelpers.js
@@ -50,7 +50,7 @@ async function getEvent(eventId, config) {
 }
 
 async function getActualAttendees(eventId, config) {
-	const resourcePath = `/v2/events/${eventId}/eventRegistrations`;
+	const resourcePath = `/v2/events/${eventId}/eventRegistrations?pageSize=200`;
 	const httpVerb = 'GET';
 	const url = N_BASE_URL + resourcePath;
 


### PR DESCRIPTION
getCurrentEvents fetches the # of registrants for an event.

But when there are cancellations, event['Registrants'] !== event['Event Registration Attendee Count'], so getCurrentEvents calls getActualAttendees() to use NEON's /eventRegistrations API to fetch the registrants. 

That api defaults to returning only 10 results per page. getActualAttendees() fetches only one page, which causes any event with >10 total registrations gets undercounted. It also filters out cancellations, so gets some number <10. (we've seen 8 and 9)

The cron then writes this wrong count to the DB, and the site displays it. Every hour it'll continue to set it to the wrong value, overriding any increments caused by webhooks.

Adding ?pageSize=200 makes the search API return all registrations in one call, fixing the undercounting issue. We don't have any events > 200 so this should be fine.

Script used to debug this:

```
const [user, key, eventId] = [process.env.NEON_API_USER, process.env.NEON_API_KEY, process.argv[2]];

fetch(`https://api.neoncrm.com/v2/events/${eventId}/eventRegistrations?pageSize=200`, {
	headers: { Authorization: `Basic ${btoa(user + ':' + key)}` }
})
	.then((r) => r.json())
	.then(({ eventRegistrations: regs, pagination }) => {
		console.log('pagination:', JSON.stringify(pagination));

		let actual = 0;
		let cronSees = 0;
		for (let i = 0; i < regs.length; i++) {
			const a = regs[i].tickets[0].attendees;
			const ok = a[0].registrationStatus === 'SUCCEEDED';
			if (ok) actual += a.length;
			if (ok && i < 10) cronSees += a.length;
			console.log((ok ? 'OK' : 'CANCELED') + ' ' + a[0].firstName + ' ' + a[0].lastName);
			if (i === 9) console.log('--- cron cutoff (only sees above) ---');
		}
		console.log('\nActual attendees: ' + actual, '; Cron would count: ' + cronSees);
	});

fetch(`https://api.neoncrm.com/v2/events/search`, {
	method: 'POST',
	headers: { Authorization: `Basic ${btoa(user + ':' + key)}`, 'Content-Type': 'application/json' },
	body: JSON.stringify({
		searchFields: [{ field: 'Event End Date', operator: 'GREATER_AND_EQUAL', value: new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0] }],
		outputFields: ['Event ID', 'Registrants', 'Event Registration Attendee Count'],
		pagination: { currentPage: 0, pageSize: 200 }
	})
})
	.then((r) => r.json())
	.then((d) => {
		const e = d.searchResults?.find((e) => e['Event ID'] === eventId);
		if (!e) return console.log('Event not in search API');
		console.log('Registrants=' + e['Registrants'] + ' AttendeeCount=' + e['Event Registration Attendee Count'] + ' equal=' + (e['Registrants'] === e['Event Registration Attendee Count']));
	});

```

Calling on a problematic event:

```
% NEON_API_USER=... NEON_API_KEY=... node debug-neon-sync.js 96386
pagination: {"currentPage":0,"pageSize":200,"sortColumn":null,"sortDirection":null,"totalPages":1,"totalResults":15}
CANCELED
CANCELED
OK
OK
OK
OK
OK
OK
OK
CANCELED
--- cron cutoff (only sees above) ---
OK
OK
OK
OK
OK

Actual attendees: 12 ; Cron would count: 7
Registrants=12 AttendeeCount=15 equal=false
```